### PR TITLE
Von misses truss example enhancement 

### DIFF
--- a/examples/vonMisesTruss/von_misses_truss.jl
+++ b/examples/vonMisesTruss/von_misses_truss.jl
@@ -21,9 +21,9 @@ steel = SVK(E, ν, "steel")
 # Geometries
 # -------------------------------
 ## Cross sections
-d = sqrt(4 * Aₒ / pi)
+d = sqrt(4 * A₀ / pi)
 s₁ = Circle(d)
-a = sqrt(Aₒ)
+a = sqrt(A₀)
 s₂ = Square(a)
 # -------------------------------
 # Create mesh
@@ -35,7 +35,7 @@ n₃ = Node(2V, 0.0, 0.0)
 vec_nodes = [n₁, n₂, n₃]
 ## Elements 
 truss₁ = Truss(n₁, n₂, s₁, "left_truss") # [n₁, n₂]
-truss₂ = Truss(n₂, n₃, s₁, "right_truss") # [n₂, n₃]
+truss₂ = Truss(n₂, n₃, s₂, "right_truss") # [n₂, n₃]
 vec_elems = [truss₁, truss₂]
 ## Mesh
 s_mesh = Mesh(vec_nodes, vec_elems)

--- a/test/static_analysis.jl
+++ b/test/static_analysis.jl
@@ -5,7 +5,7 @@ using Test: @testset, @test
 using LinearAlgebra: norm
 using ONSAS.StructuralAnalyses.StaticAnalyses
 
-const RTOL = 1e-2
+const RTOL = 5e-2
 
 ## scalar parameters
 E = 210e9  # Young modulus in Pa


### PR DESCRIPTION
This PR includes:

-  Analytic solution for rotated engineer strain. 
- Both `Square` and `Circle` cross sections with the same area for both truss elements. 

Closes #68

The overflow issue with the tests will be solved in another PR #73  