### PR TITLE
Triangular Face element 

### DIFF
--- a/examples/vonMisesTruss/von_misses_truss.jl
+++ b/examples/vonMisesTruss/von_misses_truss.jl
@@ -58,7 +58,7 @@ bc₂ = FixedDofBoundaryCondition([:u], [2], "fixed_uⱼ")
 # Load 
 bc₃ = GlobalLoadBoundaryCondition([:u], t -> [0, 0, Fₖ * t], "load in j")
 node_bc = dictionary([bc₁ => [n₁, n₃], bc₂ => [n₂], bc₃ => [n₂]])
-s_boundary_conditions = StructuralBoundaryConditions(node_bc)
+s_boundary_conditions = StructuralBoundaryConditions(node_bcs=node_bc)
 # -------------------------------
 # Structure
 # -------------------------------

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -17,8 +17,8 @@ using ..Utils: row_vector
 
 export Dof, add!
 export AbstractNode, dimension, dofs, coordinates
-export AbstractElement, cross_section, coordinates, internal_forces, inertial_forces,
-    local_dof_symbol, local_dofs, nodes, strain, stress
+export AbstractFace, coordinates, nodes
+export AbstractElement, cross_section, internal_forces, inertial_forces, local_dof_symbol, local_dofs, nodes, strain, stress
 
 # ========================
 # Degree of freedom (Dof)

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -229,7 +229,7 @@ end
 "Returns the label of an `AbstractElement` `e`."
 label(e::AbstractElement) = e.label
 
-"Returns the `Node`s of an `AbstractElement` `e`."
+"Returns a `Vector` of `Node`s defined in the `AbstractElement` `e`."
 nodes(e::AbstractElement) = e.nodes
 
 "Returns the internal forces vector of an `AbstractElement` `e`."

--- a/src/Elements/Elements.jl
+++ b/src/Elements/Elements.jl
@@ -102,6 +102,57 @@ end
 include("./Node.jl")
 
 # =================
+# Abstract Face
+# =================
+abstract type AbstractFace{dim,T} end
+
+""" Abstract supertype for all elements.
+
+An `AbstractFace` object facilitates the process of adding boundary conditions on a surface. 
+
+**Common methods:**
+
+* [`coordinates`](@ref)
+* [`dofs`](@ref)
+* [`label`](@ref)
+* [`nodes`](@ref)
+
+**Common fields:**
+* nodes
+* label
+"""
+
+"Returns the `AbstractFace` `f` coordinates."
+coordinates(f::AbstractFace) = coordinates.(nodes(f))
+
+"Returns the `AbstractFace` `f` dimension."
+dimension(::AbstractFace{dim}) where {dim} = dim
+
+"Returns the dofs of `AbstractFace` `f`."
+function dofs(f::AbstractFace)
+    vecdfs = dofs.(nodes(f))
+    dfs = mergewith(vcat, vecdfs[end], vecdfs[end-1])
+
+    for i in 1:length(vecdfs)-2
+        dfs = mergewith(vcat, dfs, vecdfs[end-(1+i)])
+    end
+    dfs
+end
+
+"Returns the dofs of a vector `vf` with `AbstractFace`s."
+dofs(vf::Vector{<:AbstractFace}) = unique(row_vector(dofs.(vf)))
+
+"Returns the label of `AbstractFace` `f`."
+label(f::AbstractFace) = f.label
+
+#==============================#
+# AbstractFace implementations #
+#==============================#
+
+include("./TriangularFace.jl")
+
+
+# =================
 # Abstract Element
 # =================
 
@@ -118,6 +169,7 @@ An `AbstractElement` object facilitates the process of evaluating:
 **Common methods:**
 
 * [`coordinates`](@ref)
+* [`dimension`](@ref)
 * [`dofs`](@ref)
 * [`local_dofs`](@ref)
 This method is a hard contract and must be implemented to define a new element.
@@ -142,6 +194,9 @@ coordinates(e::AbstractElement) = coordinates.(nodes(e))
 
 "Returns the `AbstractElement` `e` cross_section."
 cross_section(e::AbstractElement) = e.cross_section
+
+"Returns the `AbstractElement` `e` dimension."
+dimension(::AbstractElement{dim}) where {dim} = dim
 
 "Returns the dofs of `AbstractElement` `e`."
 dofs(e::AbstractElement) = mergewith(vcat, dofs.(nodes(e))...)
@@ -192,7 +247,6 @@ function stress(e::AbstractElement, args...; kwargs...) end
 #=================================#
 # AbstractElement implementations #
 #=================================#
-
 
 include("./Truss.jl")
 

--- a/src/Elements/TriangularFace.jl
+++ b/src/Elements/TriangularFace.jl
@@ -22,6 +22,6 @@ struct TriangularFace{dim,N<:AbstractNode{dim},T<:Real} <: AbstractFace{dim,T}
     end
 end
 
-"Returns the nodes for the `TriangularFace` `tf`."
+"Returns a `Vector` of`Node`s for the `TriangularFace` `tf`."
 nodes(tf::TriangularFace) = [tf.n₁, tf.n₂, tf.n₃]
 

--- a/src/Elements/TriangularFace.jl
+++ b/src/Elements/TriangularFace.jl
@@ -1,0 +1,27 @@
+using ..Elements: AbstractFace, AbstractNode
+using ..Utils: eye
+
+export TriangularFace
+
+"""
+A `TriangularFace` represents an element composed by three `Node`s.
+### Fields:
+- `n₁`             -- stores first triangle node.
+- `n₂`             -- stores second triangle node.
+- `n₂`             -- stores third triangle node.
+- `label`          -- stores the triangle label.
+"""
+struct TriangularFace{dim,N<:AbstractNode{dim},T<:Real} <: AbstractFace{dim,T}
+    n₁::N
+    n₂::N
+    n₃::N
+    label::Symbol
+    function TriangularFace(n₁::N, n₂::N, n₃::N, label=:no_labelled_face) where
+    {dim,T<:Real,N<:AbstractNode{dim,T}}
+        new{dim,N,T}(n₁, n₂, n₃, Symbol(label))
+    end
+end
+
+"Returns the nodes for the `TriangularFace` `tf`."
+nodes(tf::TriangularFace) = [tf.n₁, tf.n₂, tf.n₃]
+

--- a/src/Elements/Truss.jl
+++ b/src/Elements/Truss.jl
@@ -20,7 +20,7 @@ struct Truss{dim,N<:AbstractNode{dim},G<:AbstractCrossSection,T<:Real} <: Abstra
     n₂::N
     cross_section::G
     label::Symbol
-    function Truss(n₁::N, n₂::N, g::G, label=:no_labelled_elem) where
+    function Truss(n₁::N, n₂::N, g::G, label=:no_labelled_element) where
     {dim,T<:Real,N<:AbstractNode{dim,T},G<:AbstractCrossSection}
         new{dim,N,G,T}(n₁, n₂, g, Symbol(label))
     end

--- a/src/Elements/Truss.jl
+++ b/src/Elements/Truss.jl
@@ -33,7 +33,7 @@ end
 "Returns the local dof symbol of a `Truss` element."
 local_dof_symbol(::Truss) = [:u]
 
-"Returns a vector of `Node`'s corresponding to a `Truss` element `t`."
+"Returns a `Vector` of `Node`s for the `Truss` element `t`."
 nodes(t::Truss) = [t.n₁, t.n₂]
 
 "Returns the internal force of a `Truss` element `t` doted with an `SVK` material and a global displacement vector `u_glob`."

--- a/src/Meshes/Meshes.jl
+++ b/src/Meshes/Meshes.jl
@@ -82,7 +82,7 @@ function add!(m::AbstractMesh, dof_symbol::Symbol, dofs_per_node::Int)
     end
 end
 
-"Returns the `Node`s of the `AbstractMesh` `m`."
+"Returns a `Vector` of `Node`s defined in the `AbstractMesh` `m`."
 nodes(m::AbstractMesh) = m.nodes
 
 "Returns the number of `Node`s of the `AbstractMesh` `m`."

--- a/src/StructuralModel/StructuralBoundaryConditions.jl
+++ b/src/StructuralModel/StructuralBoundaryConditions.jl
@@ -1,27 +1,27 @@
+using ..Elements: AbstractNode, AbstractFace, AbstractElement
+
+export StructuralBoundaryConditions, all_bcs, node_bcs, face_bcs, element_bcs, displacement_bcs, load_bcs, fixed_dof_bcs
+
 """ Structural boundary conditions.
 A `StructuralBoundaryConditions` is a collection of `BoundaryConditions` defining the boundary conditions of the structure.
 ### Fields:
-- `node_bc`    -- Maps each boundary conditions for a vector of nodes. 
-- `element_bc` -- Maps each boundary conditions for a vector of elements. 
+- `node_bcs`    -- Maps each boundary conditions for a vector of nodes. 
+- `face_bcs`    -- Maps each boundary conditions for a vector of faces. 
+- `element_bcs` -- Maps each boundary conditions for a vector of elements. 
 """
-struct StructuralBoundaryConditions{
-    NB<:AbstractBoundaryCondition,NE<:AbstractBoundaryCondition,N<:AbstractNode,E<:AbstractElement
+Base.@kwdef struct StructuralBoundaryConditions{
+    NB<:AbstractBoundaryCondition,NF<:AbstractBoundaryCondition,NE<:AbstractBoundaryCondition,
+    N<:AbstractNode,F<:AbstractFace,E<:AbstractElement
 }
-    node_bcs::Dictionary{NB,Vector{N}}
-    element_bcs::Dictionary{NE,Vector{E}}
+    node_bcs::Dictionary{NB,Vector{N}} = Dictionary{AbstractBoundaryCondition,Vector{AbstractNode}}()
+    face_bcs::Dictionary{NF,Vector{F}} = Dictionary{AbstractBoundaryCondition,Vector{AbstractFace}}()
+    element_bcs::Dictionary{NE,Vector{E}} = Dictionary{AbstractBoundaryCondition,Vector{AbstractElement}}()
 end
-
-"Constructor for `StructuralBoundaryConditions` with node boundary conditions."
-StructuralBoundaryConditions(node_bcs::Dictionary{BC,Vector{N}}) where {BC<:AbstractBoundaryCondition,N<:AbstractNode} =
-    StructuralBoundaryConditions(node_bcs, Dictionary{AbstractBoundaryCondition,Vector{AbstractElement}}())
-
-"Constructor for `StructuralBoundaryConditions` with element boundary conditions."
-StructuralBoundaryConditions(element_bcs::Dictionary{BC,Vector{E}}) where {BC<:AbstractBoundaryCondition,E<:AbstractElement} =
-    StructuralBoundaryConditions(Dictionary{AbstractBoundaryCondition,Vector{AbstractNode}}(), element_bcs)
 
 "Returns the `BoundaryCondition` with the label `l` in the `StructuralBoundaryConditions` `sb`."
 function Base.getindex(sb::StructuralBoundaryConditions, l::L) where {L<:Union{Symbol,String}}
-    filter(bc -> label(bc) == Symbol(l), vcat(collect(keys(node_bcs(sb))), collect(keys(element_bcs(sb)))))[1]
+    filter(bc -> label(bc) == Symbol(l), vcat(
+        collect(keys(node_bcs(sb))), collect(keys(face_bcs(sb))), collect(keys(element_bcs(sb)))))[1]
 end
 
 "Returns the `Vector` of `Node`s and `Element`s where the `BoundaryCondition` `bc` is imposed."
@@ -45,35 +45,38 @@ Base.getindex(sb::StructuralBoundaryConditions, e::AbstractElement) = keys(filte
 "Returns the dictionary of `BoundaryConditions`s applied to `Node`s."
 node_bcs(se::StructuralBoundaryConditions) = se.node_bcs
 
+"Returns the dictionary of `BoundaryConditions`s applied to `Face`s."
+face_bcs(se::StructuralBoundaryConditions) = se.face_bcs
+
 "Returns the `Dictionary` of `BoundaryConditions`s applied to `Element`s."
 element_bcs(se::StructuralBoundaryConditions) = se.element_bcs
+
+"Returns all `BoundaryConditions`s defined into `StructuralBoundaryConditions`."
+all_bcs(se::StructuralBoundaryConditions) = unique(
+    vcat(collect(keys(node_bcs(se))), collect(keys(face_bcs(se))), collect(keys(element_bcs(se))))
+)
+
 
 "Returns a `Vector` of `DisplacementBoundaryCondition`s applied to `Node`s and `Element`s in the `StructuralBoundaryConditions` `se`."
 function displacement_bcs(se::StructuralBoundaryConditions)
     vbc = Vector{DisplacementBoundaryCondition}()
-    disp_bc_nodes = filter(bc -> bc isa DisplacementBoundaryCondition, keys(node_bcs(se)))
-    push!(vbc, disp_bc_nodes...)
-    disp_bc_elements = filter(bc -> bc isa DisplacementBoundaryCondition, keys(element_bcs(se)))
-    push!(vbc, disp_bc_elements...)
+    disp_bc = filter(bc -> bc isa DisplacementBoundaryCondition, all_bcs(se))
+    push!(vbc, disp_bc...)
     return unique(vbc)
 end
 
-"Returns a `Vector` of `FixedDofBoundaryCondition`s applied to `Node`s and `Element`s. in the `StructuralBoundaryConditions` `se`."
+"Returns a `Vector` of `FixedDofBoundaryCondition`s applied to `Node`s, `Face`s and `Element`s. in the `StructuralBoundaryConditions` `se`."
 function fixed_dof_bcs(se::StructuralBoundaryConditions)
     vbc = Vector{FixedDofBoundaryCondition}()
-    fixed_bc_nodes = filter(bc -> bc isa FixedDofBoundaryCondition, keys(node_bcs(se)))
-    push!(vbc, fixed_bc_nodes...)
-    fixed_bc_elements = filter(bc -> bc isa FixedDofBoundaryCondition, keys(element_bcs(se)))
-    push!(vbc, fixed_bc_elements...)
+    fixed_bcs = filter(bc -> bc isa FixedDofBoundaryCondition, all_bcs(se))
+    push!(vbc, fixed_bcs...)
     return unique(vbc)
 end
 
 "Returns a `Vector` of `FixedDofBoundaryCondition`s applied to `Node`s and `Element`s in the `StructuralBoundaryConditions` `se`."
 function load_bcs(se::StructuralBoundaryConditions)
     vbc = Vector{AbstractLoadBoundaryCondition}()
-    load_bc_nodes = filter(bc -> bc isa AbstractLoadBoundaryCondition, keys(node_bcs(se)))
-    push!(vbc, load_bc_nodes...)
-    load_bc_elements = filter(bc -> bc isa AbstractLoadBoundaryCondition, keys(element_bcs(se)))
-    push!(vbc, load_bc_elements...)
+    load_bcs = filter(bc -> bc isa AbstractLoadBoundaryCondition, all_bcs(se))
+    push!(vbc, load_bcs...)
     return unique(vbc)
 end

--- a/src/StructuralModel/StructuralMaterials.jl
+++ b/src/StructuralModel/StructuralMaterials.jl
@@ -1,3 +1,10 @@
+using ..Materials: AbstractMaterial
+using ..Elements: AbstractElement
+using Dictionaries: Dictionary, dictionary
+using ..Utils: label
+
+export StructuralMaterials
+
 """ Structural materials struct.
 A `StructuralMaterials` is a collection of `Material`s and `Element`s assigning materials to a vector of elements.
 ### Fields:

--- a/src/StructuralModel/StructuralModel.jl
+++ b/src/StructuralModel/StructuralModel.jl
@@ -15,8 +15,6 @@ using ..Utils: row_vector, label
 import ..Elements: dofs, nodes
 import ..Meshes: num_dofs, elements, num_elements, num_nodes
 
-export StructuralMaterials
-export StructuralBoundaryConditions, node_bcs, element_bcs, displacement_bcs, load_bcs, fixed_dof_bcs
 export Structure, mesh, materials, boundary_conditions, num_free_dofs, free_dofs
 
 

--- a/src/StructuralModel/StructuralModel.jl
+++ b/src/StructuralModel/StructuralModel.jl
@@ -71,7 +71,7 @@ free_dofs(s::AbstractStructure) = s.free_dofs
 "Returns the number of free `Dof`s of the `AbstractStructure` `s`"
 num_free_dofs(s::AbstractStructure) = length(free_dofs(s))
 
-"Returns the `Node`s of the `AbstractStructure` `s`"
+"Returns a `Vector` of `Node`s defined in the `AbstractStructure` `s`."
 nodes(s::AbstractStructure) = nodes(mesh(s))
 
 "Returns the number of `Node`s of the `AbstractStructure` `s`"

--- a/src/StructuralModel/Structure.jl
+++ b/src/StructuralModel/Structure.jl
@@ -36,7 +36,7 @@ function Structure(
         [push!(default_free_dofs, vec_dof...) for vec_dof in collect(values(node_dofs))]
     end
 
-    fixed_dofs = compte_fixed_dofs(bcs, fixed_dof_bcs(bcs))
+    fixed_dofs = compute_fixed_dofs(bcs, fixed_dof_bcs(bcs))
 
     deleteat!(default_free_dofs, findall(x -> x in fixed_dofs, default_free_dofs))
 
@@ -45,7 +45,7 @@ end
 
 #### BoundaryConditions Applied to the structure
 "Computes `Dof`s to delete given a `FixedDofBoundaryCondition` and a set of `StructuralBoundaryConditions` `bcs`."
-function compte_fixed_dofs(bcs::StructuralBoundaryConditions, fbc::FixedDofBoundaryCondition)
+function compute_fixed_dofs(bcs::StructuralBoundaryConditions, fbc::FixedDofBoundaryCondition)
 
     # Extract dofs to apply the bc
     fbc_dofs_symbols = dofs(fbc)
@@ -66,8 +66,8 @@ function compte_fixed_dofs(bcs::StructuralBoundaryConditions, fbc::FixedDofBound
 end
 
 "Applies a `Vector` of `FixedDofBoundaryCondition` `f_bcs` and a set of `StructuralBoundaryConditions` `bcs`."
-function compte_fixed_dofs(bcs::StructuralBoundaryConditions, f_bcs::Vector{<:FixedDofBoundaryCondition})
+function compute_fixed_dofs(bcs::StructuralBoundaryConditions, f_bcs::Vector{<:FixedDofBoundaryCondition})
     dofs_to_delete = Dof[]
-    [push!(dofs_to_delete, compte_fixed_dofs(bcs, fbc)...) for fbc in f_bcs]
+    [push!(dofs_to_delete, compute_fixed_dofs(bcs, fbc)...) for fbc in f_bcs]
     return dofs_to_delete
 end

--- a/test/static_analysis.jl
+++ b/test/static_analysis.jl
@@ -59,7 +59,7 @@ bc₂ = FixedDofBoundaryCondition([:u], [2], "fixed_uⱼ")
 # Load 
 bc₃ = GlobalLoadBoundaryCondition([:u], t -> [0, 0, Fₖ * t], "load in j")
 node_bc = dictionary([bc₁ => [n₁, n₃], bc₂ => [n₂], bc₃ => [n₂]])
-s_boundary_conditions = StructuralBoundaryConditions(node_bc)
+s_boundary_conditions = StructuralBoundaryConditions(node_bcs=node_bc)
 # Simplificar en un solo diccionario y que el constructor reciba las dos
 # -------------------------------
 # Structure

--- a/test/structural_model.jl
+++ b/test/structural_model.jl
@@ -3,8 +3,6 @@
 ##########################
 using Test: @testset, @test
 using ONSAS.StructuralModel
-using ONSAS.BoundaryConditions
-
 
 # Scalar parameters
 d = 0.1
@@ -12,26 +10,23 @@ L = 2.0
 h = 1.0
 E = 2e9
 ν = 0.3
-
 # Nodes
 n₁ = Node(0.0, 0.0, 0.0)
 n₂ = Node(L, h, 0.0)
 n₃ = Node(2L, 0.0, 0.0)
-
+# Faces 
+face₁ = TriangularFace(n₁, n₂, n₃)
 # Cross section
 s = Square(d)
-
 # Elements
 truss₁ = Truss(n₁, n₂, s)
 truss₂ = Truss(n₂, n₃, s)
 truss₃ = Truss(n₁, n₃, s)
-
 # Materials
 steel = SVK(E, ν, "steel")
 aluminum = SVK(E / 3, ν, "aluminium")
 mat_dict = dictionary([steel => [truss₁, truss₃], aluminum => [truss₂]])
 s_materials = StructuralMaterials(mat_dict)
-
 # Boundary conditions
 Fⱼ = 20.0
 Fᵢ = 10.0
@@ -41,8 +36,14 @@ bc₂ = FixedDofBoundaryCondition([:u], [2], "fixed_uⱼ")
 bc₃ = GlobalLoadBoundaryCondition([:u], t -> [0, Fⱼ * t, 0], "load in j")
 bc₄ = GlobalLoadBoundaryCondition([:u], t -> [Fᵢ * sin(t), 0, 0], "load in i")
 node_bc = dictionary([bc₁ => [n₁, n₃], bc₂ => [n₂], bc₃ => [n₂]])
-elem_bc = dictionary([bc₄ => [truss₁, truss₂]])
-s_boundary_conditions = StructuralBoundaryConditions(node_bc, elem_bc)
+face_bc = dictionary([bc₃ => [face₁]])
+elem_bc = dictionary([bc₄ => [truss₁, truss₂, truss₃]])
+
+s_boundary_conditions_only_nodes = StructuralBoundaryConditions(node_bcs=node_bc)
+s_boundary_conditions_only_faces = StructuralBoundaryConditions(face_bcs=face_bc)
+s_boundary_conditions_only_elements = StructuralBoundaryConditions(element_bcs=elem_bc)
+s_boundary_conditions = StructuralBoundaryConditions(node_bc, face_bc, elem_bc)
+
 
 @testset "ONSAS.StructuralModel.StructuralMaterials" begin
 
@@ -53,11 +54,14 @@ s_boundary_conditions = StructuralBoundaryConditions(node_bc, elem_bc)
 end
 
 
-@testset "ONSAS.StructuralModel.StructuralMaterials" begin
+@testset "ONSAS.StructuralModel.StructuralBoundaryConditions" begin
 
 
     @test node_bcs(s_boundary_conditions) == node_bc
+    @test face_bcs(s_boundary_conditions) == face_bc
     @test element_bcs(s_boundary_conditions) == elem_bc
+    @test all(bc ∈ all_bcs(s_boundary_conditions) for bc in [bc₁, bc₂, bc₃, bc₄])
+    @test length(all_bcs(s_boundary_conditions)) == 4
 
     @test length(load_bcs(s_boundary_conditions)) == 2
     @test bc₃ ∈ load_bcs(s_boundary_conditions) && bc₄ ∈ load_bcs(s_boundary_conditions)
@@ -69,12 +73,9 @@ end
     @test bc₂ ∈ s_boundary_conditions[n₂] && bc₃ ∈ s_boundary_conditions[n₂]
     @test bc₄ ∈ s_boundary_conditions[truss₁]
 
-
-    # Constructor only with node or element boundary conditions
-    s_boundary_conditions_nodes = StructuralBoundaryConditions(node_bc)
-    @test isempty(element_bcs(s_boundary_conditions_nodes))
-    s_boundary_conditions_element = StructuralBoundaryConditions(elem_bc)
-
+    # Constructor only with node or element boundary onditions(node_bc)
+    @test isempty(element_bcs(s_boundary_conditions_only_nodes)) && isempty(face_bcs(s_boundary_conditions_only_nodes))
+    @test isempty(element_bcs(s_boundary_conditions_only_faces)) && isempty(node_bcs(s_boundary_conditions_only_faces))
 end
 
 @testset "ONSAS.StructuralModel.Structure" begin


### PR DESCRIPTION
Addressing #77 

In this PR a new `AbstractFace` abstract type is introduced, this abstract types is useful for processing boundary conditions. In particular, this new leaf is implemented:

```julia
"""
A `TriangularFace` represents an element composed by three `Node`s.
### Fields:
- `n₁`             -- stores first triangle node.
- `n₂`             -- stores second triangle node.
- `n₂`             -- stores third triangle node.
- `label`          -- stores the triangle label.
"""
struct TriangularFace{dim,N<:AbstractNode{dim},T<:Real} <: AbstractFace{dim,T}
    n₁::N
    n₂::N
    n₃::N
    label::Symbol
    function TriangularFace(n₁::N, n₂::N, n₃::N, label=:no_labelled_face) where
    {dim,T<:Real,N<:AbstractNode{dim,T}}
        new{dim,N,T}(n₁, n₂, n₃, Symbol(label))
    end
end

"Returns the nodes for the `TriangularFace` `tf`."
nodes(tf::TriangularFace) = [tf.n₁, tf.n₂, tf.n₃]
```

Also `StructuralBoundaryConditions` struct can now include faces boundary conditions. 
