### PR TITLE
StructuralBoundaryConditions getindex

### DIFF
--- a/src/StructuralAnalyses/StructuralAnalyses.jl
+++ b/src/StructuralAnalyses/StructuralAnalyses.jl
@@ -178,7 +178,7 @@ current_iteration(a::AbstractStructuralAnalysis) = iteration_residuals(a.state)
 # Common methods
 # ================
 
-"Applies a fixed displacement boundary condition to the structural analysis `sa` at the current analysis time `t`"
+"Applies an `AbstractLoadBoundaryCondition` lbc into the structural analysis `sa` at the current analysis time `t`"
 function _apply!(sa::AbstractStructuralAnalysis, lbc::AbstractLoadBoundaryCondition)
 
     t = current_time(sa)
@@ -187,7 +187,7 @@ function _apply!(sa::AbstractStructuralAnalysis, lbc::AbstractLoadBoundaryCondit
     # Extract dofs to apply the bc
     lbc_dofs_symbols = dofs(lbc)
 
-    # Extract nodes and elements 
+    # Extract nodes, faces and element 
     entities = bcs[lbc]
     dofs_lbc = Dof[]
 

--- a/src/StructuralModel/StructuralMaterials.jl
+++ b/src/StructuralModel/StructuralMaterials.jl
@@ -19,14 +19,14 @@ end
 
 "Returns the `Material` mapped with the label `l`."
 Base.getindex(sm::StructuralMaterials, l::L) where {L<:Union{Symbol,String}} =
-    collect(filter(m -> label(m) == Symbol(l), keys(sm.mats_to_elems)))[1]
+    first(collect(filter(m -> label(m) == Symbol(l), keys(sm.mats_to_elems))))
 
 "Returns the `Vector` of `Element`s that are conformed by the `Material `m`."
 Base.getindex(sm::StructuralMaterials, m::M) where {M<:AbstractMaterial} = sm.mats_to_elems[m]
 
 "Returns the `Vector` of `Material` of the element `e`."
 Base.getindex(sm::StructuralMaterials, e::E) where {E<:AbstractElement} =
-    [m for (m, es) in pairs(sm.mats_to_elems) if e in es][1]
+    first([m for (m, es) in pairs(sm.mats_to_elems) if e in es])
 
 "Returns `Pair`s of `Material` and `Element` in the `StructuralMaterials` `sm`."
 Base.pairs(sm::StructuralMaterials) = pairs(sm.mats_to_elems)

--- a/src/StructuralModel/Structure.jl
+++ b/src/StructuralModel/Structure.jl
@@ -1,4 +1,8 @@
-# Structure 
+using ..Meshes: AbstractMesh
+using ..BoundaryConditions: FixedDofBoundaryCondition
+using ..StructuralModel: AbstractStructure, StructuralMaterials, StructuralBoundaryConditions
+
+
 """
 An `Structure` object facilitates the process of assembling and creating the structural analysis. 
 ### Fields:
@@ -50,7 +54,7 @@ function compute_fixed_dofs(bcs::StructuralBoundaryConditions, fbc::FixedDofBoun
     # Extract dofs to apply the bc
     fbc_dofs_symbols = dofs(fbc)
 
-    # Extract nodes and elements 
+    # Extract nodes, faces and elements 
     entities = bcs[fbc]
 
     dofs_to_delete = Dof[]

--- a/test/elements.jl
+++ b/test/elements.jl
@@ -26,7 +26,7 @@ node_eltypes = [Float32, Float64, Int]
 node_eltype = rand(node_eltypes)
 xᵢ = node_eltype(rand(-100:100))
 x_sa2D = SVector(xᵢ, 2xᵢ)
-x_vec2D = [xᵢ, 2xᵢ, 3xᵢ]
+x_vec2D = [xᵢ, 2xᵢ]
 x_tup2D = (xᵢ, 2xᵢ)
 x_test_vec_2D = [x_sa2D, x_vec2D, x_tup2D]
 x_test_2D = rand(x_test_vec_2D)
@@ -40,7 +40,7 @@ x_test_3D = rand(x_test_vec_3D)
 
     node = Node(x_test_2D[1], x_test_2D[2])
     @test all([node[i] == xᵢ for (i, xᵢ) in enumerate(coordinates(node))])
-    @test dimension(node) == length(x_test_2D)
+    @test dimension(node) == length(x_vec2D)
 
     # Dofs
     first_dof = 1

--- a/test/structural_model.jl
+++ b/test/structural_model.jl
@@ -37,7 +37,7 @@ bc₃ = GlobalLoadBoundaryCondition([:u], t -> [0, Fⱼ * t, 0], "load in j")
 bc₄ = GlobalLoadBoundaryCondition([:u], t -> [Fᵢ * sin(t), 0, 0], "load in i")
 node_bc = dictionary([bc₁ => [n₁, n₃], bc₂ => [n₂], bc₃ => [n₂]])
 face_bc = dictionary([bc₃ => [face₁]])
-elem_bc = dictionary([bc₄ => [truss₁, truss₂, truss₃]])
+elem_bc = dictionary([bc₄ => [truss₁, truss₂], bc₃ => [truss₃]])
 
 s_boundary_conditions_only_nodes = StructuralBoundaryConditions(node_bcs=node_bc)
 s_boundary_conditions_only_faces = StructuralBoundaryConditions(face_bcs=face_bc)
@@ -69,7 +69,9 @@ end
     @test bc₁ ∈ fixed_dof_bcs(s_boundary_conditions) && bc₂ ∈ fixed_dof_bcs(s_boundary_conditions)
 
     @test s_boundary_conditions["fixed_uⱼ"] == bc₂
-    @test truss₁ ∈ s_boundary_conditions[bc₄] && n₂ ∈ s_boundary_conditions[bc₃]
+    @test truss₁ ∈ s_boundary_conditions[bc₄]
+    @test truss₃ ∈ s_boundary_conditions[bc₃] && face₁ ∈ s_boundary_conditions[bc₃] && n₂ ∈ s_boundary_conditions[bc₃]
+    @test length(s_boundary_conditions[bc₃]) == 3
     @test bc₂ ∈ s_boundary_conditions[n₂] && bc₃ ∈ s_boundary_conditions[n₂]
     @test bc₄ ∈ s_boundary_conditions[truss₁]
 


### PR DESCRIPTION
Addressing #77 

This way of indexing `StructuralBoundaryConditions` is crucial for adding the  boundary conditions to the corresponding `Dof`s : 

Since all entities ( an entitiy is considered  as `(typeof(entity) <: Union{AbstractElement, AbstractNode, AbstractFace}))` , where  a `bc` is imposed are computed using: 

```julia
"Applies an `AbstractLoadBoundaryCondition` lbc into the structural analysis `sa` at the current analysis time `t`"
function _apply!(sa::AbstractStructuralAnalysis, lbc::AbstractLoadBoundaryCondition)

    t = current_time(sa)
    bcs = boundary_conditions(structure(sa))

    # Extract dofs to apply the bc
    lbc_dofs_symbols = dofs(lbc)

    # Extract nodes, faces and element 
    entities = bcs[lbc]
    dofs_lbc = Dof[]

    for dof_symbol in lbc_dofs_symbols
        dofs_lbc_symbol = row_vector(getindex.(dofs.(entities), dof_symbol))
        push!(dofs_lbc, dofs_lbc_symbol...)
    end

    # Repeat the bc values vector to fill a vector of dofs
    dofs_values = lbc(t)
    repeat_mod = Int(length(dofs_lbc) / length(dofs_values))

    external_forces(current_state(sa))[dofs_lbc] = repeat(dofs_values, outer=repeat_mod)

end
 ```