### PR TITLE
Boundary condition module (#87)

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -10,7 +10,7 @@ using Reexport: @reexport
 @reexport import ..Elements: dofs
 @reexport import ..Utils: label
 
-export AbstractBoundaryCondition, AbstractDisplacementBoundaryCondition, AbstractLoadBoundaryCondition
+export AbstractBoundaryCondition, AbstractDisplacementBoundaryCondition, AbstractLoadBoundaryCondition, apply
 export DisplacementBoundaryCondition, FixedDofBoundaryCondition, components
 export GlobalLoadBoundaryCondition, LocalLoadBoundaryCondition
 
@@ -27,8 +27,10 @@ An `AbstractBoundaryCondition` object facilitates the process of defining:
 * [`dofs`](@ref)
 * [`label`](@ref)
 """
-
 abstract type AbstractBoundaryCondition end
+
+"Applies the boundary condition `bc` to an`entity`."
+function apply(bc::AbstractBoundaryCondition, entity) end
 
 "Returns the degrees of freedom symbol where the boundary condition is imposed"
 dofs(bc::AbstractBoundaryCondition) = bc.dofs
@@ -47,82 +49,21 @@ Base.values(bc::AbstractBoundaryCondition) = bc.values
 """ Abstract supertype for all displacement boundary conditions."""
 abstract type AbstractDisplacementBoundaryCondition <: AbstractBoundaryCondition end
 
-""" Generalized displacement boundary condition struct.
-### Fields:
-- `dofs`    -- Vectors of symbols the where the boundary condition is subscripted. 
-- `values`  -- Values imposed function. 
-- `name`    -- Boundary condition label.
-"""
-Base.@kwdef struct DisplacementBoundaryCondition <: AbstractDisplacementBoundaryCondition
-    dofs::Vector{Symbol}
-    values::Function
-    name::Symbol = :no_labelled_bc
-end
-
-
-""" Fixed displacement boundary condition struct:
-This is a particular instance of the struct `DisplacementBoundaryCondition`
-    considering null dof value at an specific component of the dof displacements
-### Fields:
-- `dofs`             -- Vectors of symbols the where the boundary condition is subscribed.
-- `components` -- Vectors of integer indicating the degree of freedom component fixed.
-- `name`             -- Boundary condition label.
-"""
-Base.@kwdef struct FixedDofBoundaryCondition <: AbstractDisplacementBoundaryCondition
-    dofs::Vector{Symbol}
-    components::Vector{Int}
-    name::Symbol = :no_labelled_bc
-end
-
-FixedDofBoundaryCondition(dofs::Vector{Symbol}, components::Vector{Int}, name::String="no_labelled_bc") =
-    FixedDofBoundaryCondition(dofs, components, Symbol(name))
-
-components(bc::FixedDofBoundaryCondition) = bc.components
+include("FixedDofBoundaryCondition.jl")
+include("DisplacementBoundaryCondition.jl")
 
 # ========================
 # Load Boundary Conditions 
 # =========================
 
 """ Abstract supertype for all displacement boundary conditions."""
-
 abstract type AbstractLoadBoundaryCondition <: AbstractBoundaryCondition end
 
 " Abstract functor for a `AbstractLoadBoundaryCondition` returns the load at time `t`. "
 (lbc::AbstractLoadBoundaryCondition)(t::Real) = values(lbc)(t)
 
-""" Load boundary condition imposed in local coordinates of the element.
-### Fields:
-- `dofs`   -- Degrees of freedom where the boundary condition is imposed. 
-- `values` -- Values imposed function. 
-- `name`   -- Boundary condition label.
-"""
-struct LocalLoadBoundaryCondition <: AbstractLoadBoundaryCondition
-    dofs::Vector{Symbol}
-    values::Function
-    name::Symbol
-end
-
-"Constructor for `LocalLoadBoundaryCondition` with a string label."
-LocalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String="no_labelled_bc") =
-    LocalLoadBoundaryCondition(dofs, values, Symbol(name))
-
-
-""" Load boundary condition imposed in global coordinates of the element.
-### Fields:
-- `dofs`   -- Degrees of freedom where the boundary condition is imposed. 
-- `values` -- Values imposed function. 
-- `name`   -- Boundary condition label.
-"""
-struct GlobalLoadBoundaryCondition <: AbstractLoadBoundaryCondition
-    dofs::Vector{Symbol}
-    values::Function
-    name::Symbol
-end
-
-"Constructor for `LocalLoadBoundaryCondition` with a string label."
-GlobalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String="no_labelled_bc") =
-    GlobalLoadBoundaryCondition(dofs, values, Symbol(name))
-
+include("GlobalLoadBoundaryCondition.jl")
+include("LocalLoadBoundaryCondition.jl")
 
 end # module
 

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -10,7 +10,7 @@ using Reexport: @reexport
 @reexport import ..Elements: dofs
 @reexport import ..Utils: label
 
-export AbstractBoundaryCondition, AbstractDisplacementBoundaryCondition, AbstractLoadBoundaryCondition, apply
+export AbstractBoundaryCondition, AbstractDisplacementBoundaryCondition, AbstractLoadBoundaryCondition, _apply
 export DisplacementBoundaryCondition, FixedDofBoundaryCondition, components
 export GlobalLoadBoundaryCondition, LocalLoadBoundaryCondition
 
@@ -30,7 +30,7 @@ An `AbstractBoundaryCondition` object facilitates the process of defining:
 abstract type AbstractBoundaryCondition end
 
 "Applies the boundary condition `bc` to an`entity`."
-function apply(bc::AbstractBoundaryCondition, entity) end
+function _apply(bc::AbstractBoundaryCondition, entity) end
 
 "Returns the degrees of freedom symbol where the boundary condition is imposed"
 dofs(bc::AbstractBoundaryCondition) = bc.dofs

--- a/src/BoundaryConditions/DisplacementBoundaryCondition.jl
+++ b/src/BoundaryConditions/DisplacementBoundaryCondition.jl
@@ -1,0 +1,16 @@
+using ..BoundaryConditions: AbstractDisplacementBoundaryCondition
+using ..Elements: AbstractNode, AbstractFace, AbstractElement
+
+export DisplacementBoundaryCondition
+
+""" Generalized displacement boundary condition struct.
+### Fields:
+- `dofs`    -- Vectors of symbols the where the boundary condition is subscripted. 
+- `values`  -- Values imposed function. 
+- `name`    -- Boundary condition label.
+"""
+Base.@kwdef struct DisplacementBoundaryCondition <: AbstractDisplacementBoundaryCondition
+    dofs::Vector{Symbol}
+    values::Function
+    name::Symbol = :no_labelled_bc
+end

--- a/src/BoundaryConditions/DisplacementBoundaryCondition.jl
+++ b/src/BoundaryConditions/DisplacementBoundaryCondition.jl
@@ -14,3 +14,5 @@ Base.@kwdef struct DisplacementBoundaryCondition <: AbstractDisplacementBoundary
     values::Function
     name::Symbol = :no_labelled_bc
 end
+
+

--- a/src/BoundaryConditions/FixedDofBoundaryCondition.jl
+++ b/src/BoundaryConditions/FixedDofBoundaryCondition.jl
@@ -1,7 +1,7 @@
 using ..BoundaryConditions: AbstractDisplacementBoundaryCondition
 using ..Elements: Dof, AbstractNode, AbstractFace, AbstractElement, nodes
 
-import ..BoundaryConditions: apply
+import ..BoundaryConditions: _apply
 
 export components
 
@@ -27,7 +27,7 @@ components(bc::FixedDofBoundaryCondition) = bc.components
 
 
 "Returns fixed `Dof`s of an `AbstractNode` imposed in the `FixedDofBoundaryCondition` `fbc`."
-function apply(fbc::FixedDofBoundaryCondition, n::AbstractNode)
+function _apply(fbc::FixedDofBoundaryCondition, n::AbstractNode)
     fbc_dofs_symbols = dofs(fbc)
     dofs_to_delete = Dof[]
     for dof_symbol in fbc_dofs_symbols
@@ -37,8 +37,8 @@ function apply(fbc::FixedDofBoundaryCondition, n::AbstractNode)
 end
 
 "Returns fixed `Dof`s of an `AbstractFace` or `AbstractElement` imposed in the `FixedDofBoundaryCondition` `fbc`."
-function apply(fbc::FixedDofBoundaryCondition, e::E) where {E<:Union{AbstractFace,AbstractElement}}
+function _apply(fbc::FixedDofBoundaryCondition, e::E) where {E<:Union{AbstractFace,AbstractElement}}
     dofs_to_delete = Dof[]
-    [push!(dofs_to_delete, apply(fbc, n)...) for n in nodes(e)]
+    [push!(dofs_to_delete, _apply(fbc, n)...) for n in nodes(e)]
     dofs_to_delete
 end

--- a/src/BoundaryConditions/FixedDofBoundaryCondition.jl
+++ b/src/BoundaryConditions/FixedDofBoundaryCondition.jl
@@ -1,0 +1,44 @@
+using ..BoundaryConditions: AbstractDisplacementBoundaryCondition
+using ..Elements: Dof, AbstractNode, AbstractFace, AbstractElement, nodes
+
+import ..BoundaryConditions: apply
+
+export components
+
+""" Fixed displacement boundary condition struct:
+This is a particular instance of the struct `DisplacementBoundaryCondition`
+    considering null dof value at an specific component of the dof displacements
+### Fields:
+- `dofs`             -- Vectors of symbols the where the boundary condition is subscribed.
+- `components` -- Vectors of integer indicating the degree of freedom component fixed.
+- `name`             -- Boundary condition label.
+"""
+Base.@kwdef struct FixedDofBoundaryCondition <: AbstractDisplacementBoundaryCondition
+    dofs::Vector{Symbol}
+    components::Vector{Int}
+    name::Symbol = :no_labelled_bc
+end
+
+FixedDofBoundaryCondition(dofs::Vector{Symbol}, components::Vector{Int}, name::String="no_labelled_bc") =
+    FixedDofBoundaryCondition(dofs, components, Symbol(name))
+
+"Returns the fixed components of the `Dof`s defined in the boundary condition `bc`."
+components(bc::FixedDofBoundaryCondition) = bc.components
+
+
+"Returns fixed `Dof`s of an `AbstractNode` imposed in the `FixedDofBoundaryCondition` `fbc`."
+function apply(fbc::FixedDofBoundaryCondition, n::AbstractNode)
+    fbc_dofs_symbols = dofs(fbc)
+    dofs_to_delete = Dof[]
+    for dof_symbol in fbc_dofs_symbols
+        push!(dofs_to_delete, getindex(dofs(n), dof_symbol)[components(fbc)]...)
+    end
+    dofs_to_delete
+end
+
+"Returns fixed `Dof`s of an `AbstractFace` or `AbstractElement` imposed in the `FixedDofBoundaryCondition` `fbc`."
+function apply(fbc::FixedDofBoundaryCondition, e::E) where {E<:Union{AbstractFace,AbstractElement}}
+    dofs_to_delete = Dof[]
+    [push!(dofs_to_delete, apply(fbc, n)...) for n in nodes(e)]
+    dofs_to_delete
+end

--- a/src/BoundaryConditions/GlobalLoadBoundaryCondition.jl
+++ b/src/BoundaryConditions/GlobalLoadBoundaryCondition.jl
@@ -21,7 +21,6 @@ end
 GlobalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String="no_labelled_bc") =
     GlobalLoadBoundaryCondition(dofs, values, Symbol(name))
 
-
 "Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to 
 the `AbstractNode` `n` at time `t`. "
 function apply(lbc::GlobalLoadBoundaryCondition, n::AbstractNode, t::Real)
@@ -38,7 +37,6 @@ function apply(lbc::GlobalLoadBoundaryCondition, n::AbstractNode, t::Real)
     "The length of the force vector must be equal to the length of the dofs vector."
 
     return dofs_lbc, f_dofs
-
 end
 
 "Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractFace` `f` at time `t`."

--- a/src/BoundaryConditions/GlobalLoadBoundaryCondition.jl
+++ b/src/BoundaryConditions/GlobalLoadBoundaryCondition.jl
@@ -1,7 +1,7 @@
 using ..BoundaryConditions: AbstractLoadBoundaryCondition
 using ..Elements: AbstractNode, AbstractFace, AbstractElement, area, volume
 
-import ..BoundaryConditions: apply
+import ..BoundaryConditions: _apply
 
 export GlobalLoadBoundaryCondition
 
@@ -23,7 +23,7 @@ GlobalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String
 
 "Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to 
 the `AbstractNode` `n` at time `t`. "
-function apply(lbc::GlobalLoadBoundaryCondition, n::AbstractNode, t::Real)
+function _apply(lbc::GlobalLoadBoundaryCondition, n::AbstractNode, t::Real)
 
     # Find dofs of the node corresponding to the dofs symbols of the boundary condition
     dofs_lbc = Dof[]
@@ -40,7 +40,7 @@ function apply(lbc::GlobalLoadBoundaryCondition, n::AbstractNode, t::Real)
 end
 
 "Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractFace` `f` at time `t`."
-function apply(lbc::GlobalLoadBoundaryCondition, f::AbstractFace, t::Real)
+function _apply(lbc::GlobalLoadBoundaryCondition, f::AbstractFace, t::Real)
 
     # Compute tension vector for each node 
     A = area(f)
@@ -63,7 +63,7 @@ end
 
 
 "Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractElement` `e` at time `t`."
-function apply(lbc::GlobalLoadBoundaryCondition, e::AbstractElement, t::Real)
+function _apply(lbc::GlobalLoadBoundaryCondition, e::AbstractElement, t::Real)
 
     # Compute tension vector for each node 
     V = volume(e)

--- a/src/BoundaryConditions/GlobalLoadBoundaryCondition.jl
+++ b/src/BoundaryConditions/GlobalLoadBoundaryCondition.jl
@@ -1,0 +1,88 @@
+using ..BoundaryConditions: AbstractLoadBoundaryCondition
+using ..Elements: AbstractNode, AbstractFace, AbstractElement, area, volume
+
+import ..BoundaryConditions: apply
+
+export GlobalLoadBoundaryCondition
+
+""" Load boundary condition imposed in global coordinates of the element.
+### Fields:
+- `dofs`   -- Degrees of freedom where the boundary condition is imposed. 
+- `values` -- Values imposed function. 
+- `name`   -- Boundary condition label.
+"""
+struct GlobalLoadBoundaryCondition <: AbstractLoadBoundaryCondition
+    dofs::Vector{Symbol}
+    values::Function
+    name::Symbol
+end
+
+"Constructor for `LocalLoadBoundaryCondition` with a string label."
+GlobalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String="no_labelled_bc") =
+    GlobalLoadBoundaryCondition(dofs, values, Symbol(name))
+
+
+"Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to 
+the `AbstractNode` `n` at time `t`. "
+function apply(lbc::GlobalLoadBoundaryCondition, n::AbstractNode, t::Real)
+
+    # Find dofs of the node corresponding to the dofs symbols of the boundary condition
+    dofs_lbc = Dof[]
+    [push!(dofs_lbc, dofs(n)[dof_symbol]...) for dof_symbol in dofs(lbc)]
+    f = lbc(t)
+
+    # Repeat the values and build the force vector for all dofs
+    f_dofs = repeat(f, outer=Int(length(dofs_lbc) / length(f)))
+
+    @assert length(f_dofs) == length(dofs_lbc)
+    "The length of the force vector must be equal to the length of the dofs vector."
+
+    return dofs_lbc, f_dofs
+
+end
+
+"Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractFace` `f` at time `t`."
+function apply(lbc::GlobalLoadBoundaryCondition, f::AbstractFace, t::Real)
+
+    # Compute tension vector for each node 
+    A = area(f)
+    p = lbc(t) * A
+    num_nodes = length(nodes(f))
+    p_nodal = p / num_nodes
+
+    # Find dofs of the node corresponding to the dofs symbols of the boundary condition
+    dofs_lbc = Dof[]
+    [push!(dofs_lbc, dofs(n)[dof_symbol]...) for dof_symbol in dofs(lbc) for n in nodes(f)]
+
+    # Repeat the values and build the tension vector for all dofs
+    p_vec = repeat(p_nodal, outer=Int(length(dofs_lbc) / length(p)))
+
+    @assert length(p_vec) == length(dofs_lbc)
+    "The length of the tension vector must be equal to the length of the dofs vector."
+
+    return dofs_lbc, p_vec
+end
+
+
+"Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractElement` `e` at time `t`."
+function apply(lbc::GlobalLoadBoundaryCondition, e::AbstractElement, t::Real)
+
+    # Compute tension vector for each node 
+    V = volume(e)
+    b = lbc(t) * V
+    num_nodes = length(nodes(e))
+    b_nodal = b / num_nodes
+
+    # Find dofs of the node corresponding to the dofs symbols of the boundary condition
+    dofs_lbc = Dof[]
+    [push!(dofs_lbc, dofs(n)[dof_symbol]...) for dof_symbol in dofs(lbc) for n in nodes(e)]
+
+    # Repeat the values and build the tension vector for all dofs
+    b_vec = repeat(b_nodal, outer=Int(length(dofs_lbc) / length(b_nodal)))
+
+    @assert length(b_vec) == length(dofs_lbc)
+    "The length of the tension vector must be equal to the length of the dofs vector."
+
+    return dofs_lbc, b_vec
+end
+

--- a/src/BoundaryConditions/LocalLoadBoundaryCondition.jl
+++ b/src/BoundaryConditions/LocalLoadBoundaryCondition.jl
@@ -1,0 +1,51 @@
+using ..BoundaryConditions: AbstractLoadBoundaryCondition
+using ..Elements: AbstractNode, AbstractFace, AbstractElement, normal_direction
+
+import ..BoundaryConditions: apply
+
+export LocalLoadBoundaryCondition
+
+""" Load boundary condition imposed in local coordinates of the element.
+### Fields:
+- `dofs`   -- Degrees of freedom where the boundary condition is imposed. 
+- `values` -- Values imposed function. 
+- `name`   -- Boundary condition label.
+"""
+struct LocalLoadBoundaryCondition <: AbstractLoadBoundaryCondition
+    dofs::Vector{Symbol}
+    values::Function
+    name::Symbol
+    function LocalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::Symbol)
+        @assert length(values(rand(1)...)) == 1 "Only a normal pressure is supported."
+        new(dofs, values, name)
+    end
+end
+
+"Constructor for `LocalLoadBoundaryCondition` with a string label."
+LocalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String="no_labelled_bc") =
+    LocalLoadBoundaryCondition(dofs, values, Symbol(name))
+
+
+"Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractFace` `f` at time `t`."
+function apply(lbc::LocalLoadBoundaryCondition, f::AbstractFace, t::Real)
+
+    # Compute tension vector for each node 
+    n = normal_direction(f)
+    A = area(f)
+    p = lbc(t)[1] * A * n
+    num_nodes = length(nodes(f))
+    p_nodal = p / num_nodes
+
+    # Find dofs of the node corresponding to the dofs symbols of the boundary condition
+    dofs_lbc = Dof[]
+    [push!(dofs_lbc, dofs(n)[dof_symbol]...) for dof_symbol in dofs(lbc) for n in nodes(f)]
+
+    # Repeat the values and build the tension vector for all dofs
+    p_vec = repeat(p_nodal, outer=Int(length(dofs_lbc) / length(p_nodal)))
+
+    @assert length(p_vec) == length(dofs_lbc)
+    "The length of the tension vector must be equal to the length of the dofs vector."
+
+    return dofs_lbc, p_vec
+end
+

--- a/src/BoundaryConditions/LocalLoadBoundaryCondition.jl
+++ b/src/BoundaryConditions/LocalLoadBoundaryCondition.jl
@@ -1,7 +1,7 @@
 using ..BoundaryConditions: AbstractLoadBoundaryCondition
 using ..Elements: AbstractNode, AbstractFace, AbstractElement, normal_direction
 
-import ..BoundaryConditions: apply
+import ..BoundaryConditions: _apply
 
 export LocalLoadBoundaryCondition
 
@@ -27,12 +27,12 @@ LocalLoadBoundaryCondition(dofs::Vector{Symbol}, values::Function, name::String=
 
 
 "Returns the dofs and the values imposed in the `GlobalLoadBoundaryCondition` `lbc` to the `AbstractFace` `f` at time `t`."
-function apply(lbc::LocalLoadBoundaryCondition, f::AbstractFace, t::Real)
+function _apply(lbc::LocalLoadBoundaryCondition, f::AbstractFace, t::Real)
 
     # Compute tension vector for each node 
     n = normal_direction(f)
     A = area(f)
-    p = lbc(t)[1] * A * n
+    p = first(lbc(t)) * A * n
     num_nodes = length(nodes(f))
     p_nodal = p / num_nodes
 

--- a/src/Elements/Tetrahedron.jl
+++ b/src/Elements/Tetrahedron.jl
@@ -29,9 +29,8 @@ end
 Tetrahedron(n₁::N, n₂::N, n₃::N, n₄::N, label=:no_labelled_element) where {N<:AbstractNode} =
   Tetrahedron(SVector(n₁, n₂, n₃, n₄), Symbol(label))
 
-"Computes the `Tetrahedron` t volume"
+"Returns the `Tetrahedron` `t` volume in the reference configuration."
 function volume(t::Tetrahedron)
-  
   d = _shape_functions_derivatives(t)
   coords = _coordinates_matrix(t)
   J = _jacobian_mat(coords, d)

--- a/src/Elements/Tetrahedron.jl
+++ b/src/Elements/Tetrahedron.jl
@@ -8,7 +8,7 @@ using ..Utils: eye
 
 import ..Elements: internal_forces, local_dof_symbol, strain, stress
 
-export Tetrahedron
+export Tetrahedron, volume
 
 """
 A `Tetrahedron` represents a 3D volume element with four nodes.
@@ -28,6 +28,17 @@ end
 
 Tetrahedron(n₁::N, n₂::N, n₃::N, n₄::N, label=:no_labelled_element) where {N<:AbstractNode} =
   Tetrahedron(SVector(n₁, n₂, n₃, n₄), Symbol(label))
+
+"Computes the `Tetrahedron` t volume"
+function volume(t::Tetrahedron)
+  
+  d = _shape_functions_derivatives(t)
+  coords = _coordinates_matrix(t)
+  J = _jacobian_mat(coords, d)
+  vol = _volume(J)
+  return vol
+end
+
 
 "Returns the local dof symbol of a `Tetrahedron` element."
 local_dof_symbol(::Tetrahedron) = [:u]

--- a/src/Materials/SVK.jl
+++ b/src/Materials/SVK.jl
@@ -58,7 +58,6 @@ function lame_parameters(svk::SVK)
     return λ, G
 end
 
-
 "Returns the Cosserat or Second-Piola Kirchoff tensor (𝕊) for a `Tetrahedron` element `t`
 considering a `SVK` material `m` and the strain tensor `𝔼`."
 function cosserat(m::SVK, 𝔼::AbstractMatrix, compute∂𝕊∂𝔼::Bool=true)

--- a/src/Meshes/Meshes.jl
+++ b/src/Meshes/Meshes.jl
@@ -29,7 +29,6 @@ The following methods are provided by the interface:
 * [`nodes`](@ref)
 * [`num_nodes`](@ref)
 """
-
 abstract type AbstractMesh{dim} end
 
 "Returns the dimension of an `AbstractMesh`."

--- a/src/StructuralAnalyses/StaticAnalyses.jl
+++ b/src/StructuralAnalyses/StaticAnalyses.jl
@@ -171,7 +171,6 @@ function _solve(sa::StaticAnalysis, alg::AbstractSolver, args...; kwargs...)
 
     states = []
 
-
     # load factors iteration 
     while !is_done(sa)
 

--- a/src/StructuralModel/StructuralBoundaryConditions.jl
+++ b/src/StructuralModel/StructuralBoundaryConditions.jl
@@ -90,7 +90,7 @@ end
 "Returns a `Vector` of `FixedDofBoundaryCondition` `f_bcs` and a set of `StructuralBoundaryConditions` `bcs`."
 function apply(bcs::StructuralBoundaryConditions, f_bcs::Vector{<:FixedDofBoundaryCondition})
     dofs_to_delete = Dof[]
-    [push!(dofs_to_delete, compute_fixed_dofs(bcs, fbc)...) for fbc in f_bcs]
+    [push!(dofs_to_delete, apply(bcs, fbc)...) for fbc in f_bcs]
     return unique!(dofs_to_delete)
 end
 

--- a/src/StructuralModel/StructuralBoundaryConditions.jl
+++ b/src/StructuralModel/StructuralBoundaryConditions.jl
@@ -59,7 +59,6 @@ all_bcs(se::StructuralBoundaryConditions) = unique(
     vcat(collect(keys(node_bcs(se))), collect(keys(face_bcs(se))), collect(keys(element_bcs(se))))
 )
 
-
 "Returns a `Vector` of `DisplacementBoundaryCondition`s applied to `Node`s and `Element`s in the `StructuralBoundaryConditions` `se`."
 function displacement_bcs(se::StructuralBoundaryConditions)
     vbc = Vector{DisplacementBoundaryCondition}()

--- a/src/StructuralModel/Structure.jl
+++ b/src/StructuralModel/Structure.jl
@@ -48,30 +48,4 @@ function Structure(
 end
 
 #### BoundaryConditions Applied to the structure
-"Computes `Dof`s to delete given a `FixedDofBoundaryCondition` and a set of `StructuralBoundaryConditions` `bcs`."
-function compute_fixed_dofs(bcs::StructuralBoundaryConditions, fbc::FixedDofBoundaryCondition)
 
-    # Extract dofs to apply the bc
-    fbc_dofs_symbols = dofs(fbc)
-
-    # Extract nodes, faces and elements 
-    entities = bcs[fbc]
-
-    dofs_to_delete = Dof[]
-
-    for dof_symbol in fbc_dofs_symbols
-        dofs_entities = getindex.(dofs.(entities), dof_symbol)
-        for component in components(fbc)
-            dofs_to_delete_fbc = getindex.(dofs_entities, component)
-            push!(dofs_to_delete, dofs_to_delete_fbc...)
-        end
-    end
-    return dofs_to_delete
-end
-
-"Applies a `Vector` of `FixedDofBoundaryCondition` `f_bcs` and a set of `StructuralBoundaryConditions` `bcs`."
-function compute_fixed_dofs(bcs::StructuralBoundaryConditions, f_bcs::Vector{<:FixedDofBoundaryCondition})
-    dofs_to_delete = Dof[]
-    [push!(dofs_to_delete, compute_fixed_dofs(bcs, fbc)...) for fbc in f_bcs]
-    return dofs_to_delete
-end

--- a/src/StructuralModel/Structure.jl
+++ b/src/StructuralModel/Structure.jl
@@ -1,5 +1,5 @@
 using ..Meshes: AbstractMesh
-using ..BoundaryConditions: FixedDofBoundaryCondition, apply
+using ..BoundaryConditions: FixedDofBoundaryCondition, _apply
 using ..StructuralModel: AbstractStructure, StructuralMaterials, StructuralBoundaryConditions
 
 
@@ -12,7 +12,7 @@ An `Structure` object facilitates the process of assembling and creating the str
 - `bcs`       -- Stores the structural boundary conditions of the structure.
 - `free_dofs` -- Stores the free degrees of freedom.
 """
-mutable struct Structure{dim,MESH,MAT,E,NB,LB} <: AbstractStructure{dim,MAT,E}
+struct Structure{dim,MESH,MAT,E,NB,LB} <: AbstractStructure{dim,MAT,E}
     mesh::MESH
     materials::StructuralMaterials{MAT,E}
     bcs::StructuralBoundaryConditions{NB,LB}
@@ -40,7 +40,7 @@ function Structure(
         [push!(default_free_dofs, vec_dof...) for vec_dof in collect(values(node_dofs))]
     end
 
-    fixed_dofs = apply(bcs, fixed_dof_bcs(bcs))
+    fixed_dofs = _apply(bcs, fixed_dof_bcs(bcs))
 
     deleteat!(default_free_dofs, findall(x -> x in fixed_dofs, default_free_dofs))
 

--- a/src/StructuralModel/Structure.jl
+++ b/src/StructuralModel/Structure.jl
@@ -1,5 +1,5 @@
 using ..Meshes: AbstractMesh
-using ..BoundaryConditions: FixedDofBoundaryCondition
+using ..BoundaryConditions: FixedDofBoundaryCondition, apply
 using ..StructuralModel: AbstractStructure, StructuralMaterials, StructuralBoundaryConditions
 
 
@@ -40,7 +40,7 @@ function Structure(
         [push!(default_free_dofs, vec_dof...) for vec_dof in collect(values(node_dofs))]
     end
 
-    fixed_dofs = compute_fixed_dofs(bcs, fixed_dof_bcs(bcs))
+    fixed_dofs = apply(bcs, fixed_dof_bcs(bcs))
 
     deleteat!(default_free_dofs, findall(x -> x in fixed_dofs, default_free_dofs))
 

--- a/test/boundary_conditions.jl
+++ b/test/boundary_conditions.jl
@@ -27,16 +27,15 @@ tetra = Tetrahedron(n₁, n₂, n₃, n₄)
     @test components(fixed_bc) == fixed_components
     @test label(fixed_bc) == generic_bc_label
 
-    @test apply(fixed_bc, n₃) == [Dof(7), Dof(9), Dof(19), Dof(21)]
-    @test apply(fixed_bc, t_face) == [Dof(1), Dof(3), Dof(13), Dof(15), Dof(4),
+    @test _apply(fixed_bc, n₃) == [Dof(7), Dof(9), Dof(19), Dof(21)]
+    @test _apply(fixed_bc, t_face) == [Dof(1), Dof(3), Dof(13), Dof(15), Dof(4),
         Dof(6), Dof(16), Dof(18), Dof(7), Dof(9), Dof(19), Dof(21)]
-    @test apply(fixed_bc, tetra) == [Dof(1), Dof(3), Dof(13), Dof(15), Dof(4), Dof(6), Dof(16),
+    @test _apply(fixed_bc, tetra) == [Dof(1), Dof(3), Dof(13), Dof(15), Dof(4), Dof(6), Dof(16),
         Dof(18), Dof(7), Dof(9), Dof(19), Dof(21), Dof(10), Dof(12), Dof(22), Dof(24)]
 
 end
 
 t_to_test = 2.0
-
 
 @testset "ONSAS.BoundaryConditions.GlobalLoadBoundaryCondition" begin
 
@@ -55,20 +54,20 @@ t_to_test = 2.0
     @test generic_bc(t_to_test) == values(generic_bc)(t_to_test)
 
     # Node force computation 
-    loaded_dofs, f_vec = apply(generic_bc, n₁, t_to_test)
+    loaded_dofs, f_vec = _apply(generic_bc, n₁, t_to_test)
     @test loaded_dofs == [Dof(1), Dof(2), Dof(3), Dof(13), Dof(14), Dof(15)]
     @test f_vec == repeat(generic_bc(t_to_test), 2)
 
     # Face tension computation 
-    loaded_dofs, p_vec = apply(generic_bc, t_face, t_to_test)
+    loaded_dofs, p_vec = _apply(generic_bc, t_face, t_to_test)
     @test loaded_dofs == vcat(Dof.(1:9), Dof.(13:21))
     @test p_vec == repeat(generic_bc(t_to_test) * area(t_face) / 3, 6)
 
     # Volume tension computation 
-    loaded_dofs, b_vec = apply(generic_bc, tetra, t_to_test)
+    loaded_dofs, b_vec = _apply(generic_bc, tetra, t_to_test)
     @test loaded_dofs == vcat(Dof.(1:24))
-    @test f_vec == repeat(generic_bc(t_to_test) * volume(t_face) / 3, 6) skip = true
 
+    @test b_vec == repeat(generic_bc(t_to_test) * volume(tetra) / 4, 8)
 
 end
 
@@ -86,11 +85,8 @@ end
     @test generic_bc(t_to_test) == values(generic_bc)(t_to_test)
 
     # Face tension computation 
-    loaded_dofs, p_vec = apply(generic_bc, t_face, t_to_test)
+    loaded_dofs, p_vec = _apply(generic_bc, t_face, t_to_test)
     @test loaded_dofs == vcat(Dof.(1:9))
     @test p_vec == repeat([generic_values(t_to_test)[1] * area(t_face) / 3, 0, 0], 3)
-
-
-
 end
 

--- a/test/boundary_conditions.jl
+++ b/test/boundary_conditions.jl
@@ -3,12 +3,23 @@
 ###################################
 using Test: @testset, @test
 using ONSAS.BoundaryConditions
+using ONSAS.Elements
+
+# Entities 
+n₁ = Node(0, 0, 0, dictionary([:u => [Dof(1), Dof(2), Dof(3)], :θ => [Dof(13), Dof(14), Dof(15)], :T => [Dof(25)]]))
+n₂ = Node(0, 1, 0, dictionary([:u => [Dof(4), Dof(5), Dof(6)], :θ => [Dof(16), Dof(17), Dof(18)], :T => [Dof(26)]]))
+n₃ = Node(0, 0, 1, dictionary([:u => [Dof(7), Dof(8), Dof(9)], :θ => [Dof(19), Dof(20), Dof(21)], :T => [Dof(27)]]))
+n₄ = Node(2, 0, 1, dictionary([:u => [Dof(10), Dof(11), Dof(12)], :θ => [Dof(22), Dof(23), Dof(24)], :T => [Dof(28)]]))
+
+t_face = TriangularFace(n₁, n₂, n₃)
+tetra = Tetrahedron(n₁, n₂, n₃, n₄)
+
 
 @testset "ONSAS.BoundaryConditions.FixedDofBoundaryCondition" begin
 
     # Generic labeled boundary condition
     generic_fixed_dofs = [:u, :θ]
-    fixed_components = [1, 2, 3] # Fixes first, second and third component of the corresponding dofs
+    fixed_components = [1, 3] # Fixes first, second and third component of the corresponding dofs
     generic_bc_label = :fixed_bc_generic
     fixed_bc = FixedDofBoundaryCondition(generic_fixed_dofs, fixed_components, generic_bc_label)
 
@@ -16,14 +27,21 @@ using ONSAS.BoundaryConditions
     @test components(fixed_bc) == fixed_components
     @test label(fixed_bc) == generic_bc_label
 
+    @test apply(fixed_bc, n₃) == [Dof(7), Dof(9), Dof(19), Dof(21)]
+    @test apply(fixed_bc, t_face) == [Dof(1), Dof(3), Dof(13), Dof(15), Dof(4),
+        Dof(6), Dof(16), Dof(18), Dof(7), Dof(9), Dof(19), Dof(21)]
+    @test apply(fixed_bc, tetra) == [Dof(1), Dof(3), Dof(13), Dof(15), Dof(4), Dof(6), Dof(16),
+        Dof(18), Dof(7), Dof(9), Dof(19), Dof(21), Dof(10), Dof(12), Dof(22), Dof(24)]
+
 end
 
+t_to_test = 2.0
 
 
 @testset "ONSAS.BoundaryConditions.GlobalLoadBoundaryCondition" begin
 
     # Generic labeled global load boundary condition
-    dofs_to_apply_bc = [:u]
+    dofs_to_apply_bc = [:u, :θ]
     load_fact_generic(t) = [sin(t), t, t^2]
     generic_values = t -> load_fact_generic(t) .* [1, 1, 1]
     generic_bc_label = :bc_generic
@@ -34,7 +52,23 @@ end
     @test dofs(generic_bc) == dofs_to_apply_bc
     @test values(generic_bc) == generic_values
     @test label(generic_bc) == generic_bc_label
-    @test generic_bc(2.0) == values(generic_bc)(2.0)
+    @test generic_bc(t_to_test) == values(generic_bc)(t_to_test)
+
+    # Node force computation 
+    loaded_dofs, f_vec = apply(generic_bc, n₁, t_to_test)
+    @test loaded_dofs == [Dof(1), Dof(2), Dof(3), Dof(13), Dof(14), Dof(15)]
+    @test f_vec == repeat(generic_bc(t_to_test), 2)
+
+    # Face tension computation 
+    loaded_dofs, p_vec = apply(generic_bc, t_face, t_to_test)
+    @test loaded_dofs == vcat(Dof.(1:9), Dof.(13:21))
+    @test p_vec == repeat(generic_bc(t_to_test) * area(t_face) / 3, 6)
+
+    # Volume tension computation 
+    loaded_dofs, b_vec = apply(generic_bc, tetra, t_to_test)
+    @test loaded_dofs == vcat(Dof.(1:24))
+    @test f_vec == repeat(generic_bc(t_to_test) * volume(t_face) / 3, 6) skip = true
+
 
 end
 
@@ -42,15 +76,21 @@ end
 
     # Generic labeled global load boundary condition
     dofs_to_apply_bc = [:u]
-    load_fact_generic(t) = [sin(t), t, t^2]
-    generic_values = t -> load_fact_generic(t) .* [1, 1, 1]
+    load_fact_generic(t) = t^2
+    generic_values = t -> load_fact_generic(t) .* [1]
     generic_bc_label = :bc_generic
-    generic_bc = LocalLoadBoundaryCondition(dofs_to_apply_bc, generic_values
-    )
+    generic_bc = LocalLoadBoundaryCondition(dofs_to_apply_bc, generic_values)
 
     @test dofs(generic_bc) == dofs_to_apply_bc
     @test values(generic_bc) == generic_values
-    @test generic_bc(2.0) == values(generic_bc)(2.0)
+    @test generic_bc(t_to_test) == values(generic_bc)(t_to_test)
+
+    # Face tension computation 
+    loaded_dofs, p_vec = apply(generic_bc, t_face, t_to_test)
+    @test loaded_dofs == vcat(Dof.(1:9))
+    @test p_vec == repeat([generic_values(t_to_test)[1] * area(t_face) / 3, 0, 0], 3)
+
+
 
 end
 

--- a/test/elements.jl
+++ b/test/elements.jl
@@ -190,6 +190,8 @@ end
         u_global₁_θ, u_global₂_θ, u_global₃_θ, u_global₄_θ,
     )
 
+    @test volume(tetra) == 2 * 1 / 6
+
     fᵢₙₜ_e, Kᵢₙₜ_e, σ_e, ϵ_e =
         internal_forces(my_svk_mat, tetra, u_global_structure[local_dofs(tetra)])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using SafeTestsets: @safetestset
 
 MODULES = [
     # Input modules
-    "materials.jl", "cross_sections.jl", "elements.jl", "meshes.jl",
+    "materials.jl", "cross_sections.jl", "elements.jl", "boundary_conditions.jl", "meshes.jl",
     # Analysis modules
     "structural_model.jl", "structural_solvers.jl", "static_analysis.jl"]
 

--- a/test/structural_model.jl
+++ b/test/structural_model.jl
@@ -11,9 +11,9 @@ h = 1.0
 E = 2e9
 ν = 0.3
 # Nodes
-n₁ = Node(0.0, 0.0, 0.0)
-n₂ = Node(L, h, 0.0)
-n₃ = Node(2L, 0.0, 0.0)
+n₁ = Node(0, 0, 0, dictionary([:u => [Dof(1), Dof(2), Dof(3)], :θ => [Dof(13), Dof(14), Dof(15)], :T => [Dof(25)]]))
+n₂ = Node(0, 1, 0, dictionary([:u => [Dof(4), Dof(5), Dof(6)], :θ => [Dof(16), Dof(17), Dof(18)], :T => [Dof(26)]]))
+n₃ = Node(0, 0, 1, dictionary([:u => [Dof(7), Dof(8), Dof(9)], :θ => [Dof(19), Dof(20), Dof(21)], :T => [Dof(27)]]))
 # Faces 
 face₁ = TriangularFace(n₁, n₂, n₃)
 # Cross section
@@ -22,6 +22,7 @@ s = Square(d)
 truss₁ = Truss(n₁, n₂, s)
 truss₂ = Truss(n₂, n₃, s)
 truss₃ = Truss(n₁, n₃, s)
+# Mesh
 # Materials
 steel = SVK(E, ν, "steel")
 aluminum = SVK(E / 3, ν, "aluminium")
@@ -35,15 +36,15 @@ bc₁ = FixedDofBoundaryCondition([:u], collect(1:dof_dim), "fixed_uₓ_uⱼ_u�
 bc₂ = FixedDofBoundaryCondition([:u], [2], "fixed_uⱼ")
 bc₃ = GlobalLoadBoundaryCondition([:u], t -> [0, Fⱼ * t, 0], "load in j")
 bc₄ = GlobalLoadBoundaryCondition([:u], t -> [Fᵢ * sin(t), 0, 0], "load in i")
-node_bc = dictionary([bc₁ => [n₁, n₃], bc₂ => [n₂], bc₃ => [n₂]])
-face_bc = dictionary([bc₃ => [face₁]])
-elem_bc = dictionary([bc₄ => [truss₁, truss₂], bc₃ => [truss₃]])
+bc₅ = FixedDofBoundaryCondition([:T], [1], "fixed_T")
+node_bc = dictionary([bc₁ => [n₁, n₃], bc₂ => [n₂], bc₃ => [n₂, n₁]])
+face_bc = dictionary([bc₃ => [face₁], bc₅ => [face₁]])
+elem_bc = dictionary([bc₄ => [truss₁, truss₂]])
 
 s_boundary_conditions_only_nodes = StructuralBoundaryConditions(node_bcs=node_bc)
 s_boundary_conditions_only_faces = StructuralBoundaryConditions(face_bcs=face_bc)
 s_boundary_conditions_only_elements = StructuralBoundaryConditions(element_bcs=elem_bc)
 s_boundary_conditions = StructuralBoundaryConditions(node_bc, face_bc, elem_bc)
-
 
 @testset "ONSAS.StructuralModel.StructuralMaterials" begin
 
@@ -55,25 +56,21 @@ end
 
 @testset "ONSAS.StructuralModel.StructuralBoundaryConditions" begin
 
-
+    # Access and filter boundary conditions
     @test node_bcs(s_boundary_conditions) == node_bc
     @test face_bcs(s_boundary_conditions) == face_bc
     @test element_bcs(s_boundary_conditions) == elem_bc
-    @test all(bc ∈ all_bcs(s_boundary_conditions) for bc in [bc₁, bc₂, bc₃, bc₄])
-    @test length(all_bcs(s_boundary_conditions)) == 4
+    @test all(bc ∈ all_bcs(s_boundary_conditions) for bc in [bc₁, bc₂, bc₃, bc₄, bc₅])
+    @test length(all_bcs(s_boundary_conditions)) == 5
 
     @test length(load_bcs(s_boundary_conditions)) == 2
     @test bc₃ ∈ load_bcs(s_boundary_conditions) && bc₄ ∈ load_bcs(s_boundary_conditions)
-    @test length(fixed_dof_bcs(s_boundary_conditions)) == 2
-    @test bc₁ ∈ fixed_dof_bcs(s_boundary_conditions) && bc₂ ∈ fixed_dof_bcs(s_boundary_conditions)
-    @test apply(s_boundary_conditions, bc₁) == vcat(Dof.(1:3), Dof.(7:9))
-    @test apply(s_boundary_conditions, bc₂) == [Dof(5)]
+    @test length(fixed_dof_bcs(s_boundary_conditions)) == 3
+    @test all(bc ∈ fixed_dof_bcs(s_boundary_conditions) for bc in [bc₁, bc₂, bc₅])
 
     @test s_boundary_conditions["fixed_uⱼ"] == bc₂
     @test truss₁ ∈ s_boundary_conditions[bc₄]
-    t_to_test = first(rand(1))
-    apply(s_boundary_conditions_only_nodes, bc₃, t_to_test)
-    @test truss₃ ∈ s_boundary_conditions[bc₃] && face₁ ∈ s_boundary_conditions[bc₃] && n₂ ∈ s_boundary_conditions[bc₃]
+    @test face₁ ∈ s_boundary_conditions[bc₃] && n₂ ∈ s_boundary_conditions[bc₃] && n₁ ∈ s_boundary_conditions[bc₃]
     @test length(s_boundary_conditions[bc₃]) == 3
     @test bc₂ ∈ s_boundary_conditions[n₂] && bc₃ ∈ s_boundary_conditions[n₂]
     @test bc₄ ∈ s_boundary_conditions[truss₁]
@@ -81,9 +78,31 @@ end
     # Constructor only with node or element boundary onditions(node_bc)
     @test isempty(element_bcs(s_boundary_conditions_only_nodes)) && isempty(face_bcs(s_boundary_conditions_only_nodes))
     @test isempty(element_bcs(s_boundary_conditions_only_faces)) && isempty(node_bcs(s_boundary_conditions_only_faces))
+
+    # Apply boundary conditions
+    @test apply(s_boundary_conditions, bc₁) == vcat(Dof.(1:3), Dof.(7:9))
+    @test apply(s_boundary_conditions, bc₂) == [Dof(5)]
+    @test apply(s_boundary_conditions, bc₅) == Dof.(25:27)
+
+    t_to_test = first(rand(1))
+    dofs_bc₃_nodes, f_bc₃_nodes = apply(s_boundary_conditions_only_nodes, bc₃, t_to_test)
+    dofs__bc₃_nodes_to_test = vcat(dofs(n₁)[dofs(bc₃)...], dofs(n₂)[dofs(bc₃)...])
+    dofs_bc₃_faces, f_bc₃_faces = apply(s_boundary_conditions_only_faces, bc₃, t_to_test)
+    dofs__bc₃_faces_to_test = vcat(dofs(n₁)[dofs(bc₃)...], dofs(n₂)[dofs(bc₃)...])
+
+    dofs_bc₃, f_bc₃ = apply(s_boundary_conditions, bc₃, t_to_test)
+
+    @test dofs_bc₃ == vcat(dofs_bc₃_nodes, dofs_bc₃_faces)
+    @test f_bc₃ == vcat(f_bc₃_nodes, f_bc₃_faces)
+
 end
 
 @testset "ONSAS.StructuralModel.Structure" begin
+
+
+    n₁ = Node(0, 0, 0)
+    n₂ = Node(0, 1, 0)
+    n₃ = Node(0, 0, 1)
 
     s_mesh = Mesh([n₁, n₂, n₃], [truss₁, truss₂, truss₃])
     add!(s_mesh, :u, dof_dim)

--- a/test/structural_model.jl
+++ b/test/structural_model.jl
@@ -80,25 +80,29 @@ end
     @test isempty(element_bcs(s_boundary_conditions_only_faces)) && isempty(node_bcs(s_boundary_conditions_only_faces))
 
     # Apply boundary conditions
-    @test apply(s_boundary_conditions, bc₁) == vcat(Dof.(1:3), Dof.(7:9))
-    @test apply(s_boundary_conditions, bc₂) == [Dof(5)]
-    @test apply(s_boundary_conditions, bc₅) == Dof.(25:27)
+    @test _apply(s_boundary_conditions, bc₁) == vcat(Dof.(1:3), Dof.(7:9))
+    @test _apply(s_boundary_conditions, bc₂) == [Dof(5)]
+    @test _apply(s_boundary_conditions, bc₅) == Dof.(25:27)
 
     t_to_test = first(rand(1))
-    dofs_bc₃_nodes, f_bc₃_nodes = apply(s_boundary_conditions_only_nodes, bc₃, t_to_test)
-    dofs__bc₃_nodes_to_test = vcat(dofs(n₁)[dofs(bc₃)...], dofs(n₂)[dofs(bc₃)...])
-    dofs_bc₃_faces, f_bc₃_faces = apply(s_boundary_conditions_only_faces, bc₃, t_to_test)
-    dofs__bc₃_faces_to_test = vcat(dofs(n₁)[dofs(bc₃)...], dofs(n₂)[dofs(bc₃)...])
+    dofs_bc₃_nodes, f_bc₃_nodes = _apply(s_boundary_conditions_only_nodes, bc₃, t_to_test)
+    dofs_load_nodes_bc₃ = dictionary(dofs_bc₃_nodes .=> f_bc₃_nodes)
+    # dofs__bc₃_nodes_to_test = vcat(dofs(n₁)[dofs(bc₃)...], dofs(n₂)[dofs(bc₃)...])
+    dofs_bc₃_faces, f_bc₃_faces = _apply(s_boundary_conditions_only_faces, bc₃, t_to_test)
+    dofs_load_faces_bc₃ = dictionary(dofs_bc₃_faces .=> f_bc₃_faces)
 
-    dofs_bc₃, f_bc₃ = apply(s_boundary_conditions, bc₃, t_to_test)
+    dofs_load_bc₃ = mergewith(+, dofs_load_nodes_bc₃, dofs_load_faces_bc₃)
+    dofs_bc₃_to_test = collect(keys(dofs_load_bc₃))
+    f_bc₃_to_test = collect(values(dofs_load_bc₃))
 
-    @test dofs_bc₃ == vcat(dofs_bc₃_nodes, dofs_bc₃_faces)
-    @test f_bc₃ == vcat(f_bc₃_nodes, f_bc₃_faces)
+    dofs_bc₃, f_bc₃ = _apply(s_boundary_conditions, bc₃, t_to_test)
+
+    @test dofs_bc₃_to_test == dofs_bc₃
+    @test f_bc₃_to_test == f_bc₃
 
 end
 
 @testset "ONSAS.StructuralModel.Structure" begin
-
 
     n₁ = Node(0, 0, 0)
     n₂ = Node(0, 1, 0)

--- a/test/structural_model.jl
+++ b/test/structural_model.jl
@@ -53,7 +53,6 @@ s_boundary_conditions = StructuralBoundaryConditions(node_bc, face_bc, elem_bc)
 
 end
 
-
 @testset "ONSAS.StructuralModel.StructuralBoundaryConditions" begin
 
 
@@ -67,9 +66,13 @@ end
     @test bc₃ ∈ load_bcs(s_boundary_conditions) && bc₄ ∈ load_bcs(s_boundary_conditions)
     @test length(fixed_dof_bcs(s_boundary_conditions)) == 2
     @test bc₁ ∈ fixed_dof_bcs(s_boundary_conditions) && bc₂ ∈ fixed_dof_bcs(s_boundary_conditions)
+    @test apply(s_boundary_conditions, bc₁) == vcat(Dof.(1:3), Dof.(7:9))
+    @test apply(s_boundary_conditions, bc₂) == [Dof(5)]
 
     @test s_boundary_conditions["fixed_uⱼ"] == bc₂
     @test truss₁ ∈ s_boundary_conditions[bc₄]
+    t_to_test = first(rand(1))
+    apply(s_boundary_conditions_only_nodes, bc₃, t_to_test)
     @test truss₃ ∈ s_boundary_conditions[bc₃] && face₁ ∈ s_boundary_conditions[bc₃] && n₂ ∈ s_boundary_conditions[bc₃]
     @test length(s_boundary_conditions[bc₃]) == 3
     @test bc₂ ∈ s_boundary_conditions[n₂] && bc₃ ∈ s_boundary_conditions[n₂]


### PR DESCRIPTION
Closes #87 

Now each method is defined to apply boundary conditions on different kind of `Element`s.
For example:

- A `FixedDofBoundaryCondition` can be superimposed to a `AbstractNode` `AbstractFace` or `AbstractElement`. In this case every 
a component to every `Dof` in the nodes of the entity is added as a fix_dof of the `Structure`

- A `GlobalLoadBoundaryCondition`  an be superimposed to a `Node` `Face` or `Element`. For this case the following assumptions are done:

-  For a `Node` a time vector is added in N to all the components of the `Dof` specified with a symbol. 
-  For a `AbstractFace` a time vector is added to all the components of the `Dof` specified with a symbol. But in this case the hole force, computed with tension * area is divided by the number of nodes  that defines the `AbstractFace`. 
-   For a `AbstractElement` a time vector is added to all the components of the `Dof` specified with a symbol. But in this case the hole force, computed with tension *volume is divided by the number of nodes  that defines the `AbstractElement`. 

- A `LocalLoadBoundaryCondition`  an be superimposed to an  `AbstractFace` and this applies a normal tension along the local normal direction at time `t` to the face nodes dofs with the symbol defined in the boundary condition. 

By the way, with this PR we reached 200 hundred unitary tests 🦺 . 


[Hey Julia performance tips jj ](https://www.youtube.com/watch?v=1WxsTfiUxxk) :neckbeard: 


