### PR TITLE
Generic `HyperElastic` material using `Tensors.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 
 [compat]
 AutoHashEquals = "0.2"

--- a/examples/uniaxial_extension/uniaxial_extension.geo
+++ b/examples/uniaxial_extension/uniaxial_extension.geo
@@ -58,4 +58,4 @@ Physical Surface ("_triangle_fixed-uj") = {6};
 Physical Surface ("_triangle_fixed-uk") = {2};
 Physical Surface ("_triangle_tension") = {3};
 //+
-Physical Volume  ("svk_tetrahedron_") = {1};
+Physical Volume  ("svkHyper_tetrahedron_") = {1};

--- a/examples/uniaxial_extension/uniaxial_extension.jl
+++ b/examples/uniaxial_extension/uniaxial_extension.jl
@@ -131,8 +131,13 @@ numeric_λᵥ_case₁ = load_factors(sa₁)
 # -------------------------------
 # Materials
 # -------------------------------
+# Define a new HyperElastic material from the strain energy function
+strain_energy_svk(𝔼, λ::Real, G::Real) = (λ / 2) * tr(𝔼)^2 + G * tr(𝔼^2)
+λ, G = lame_parameters(svk)
+params = [λ, G] # The order must be the same defined in the strain energy(splatting)
+svk_hyper_elastic = HyperElastic(params, strain_energy_svk, "svkHyper")
 # Material types without assigned elements
-mat_types = [svk]
+mat_types = [svk_hyper_elastic]
 s_materials = StructuralMaterials(mat_types)
 # -------------------------------
 # Boundary Conditions

--- a/examples/uniaxial_extension/uniaxial_extension.jl
+++ b/examples/uniaxial_extension/uniaxial_extension.jl
@@ -132,7 +132,7 @@ numeric_λᵥ_case₁ = load_factors(sa₁)
 # Materials
 # -------------------------------
 # Define a new HyperElastic material from the strain energy function
-strain_energy_svk(𝔼, λ::Real, G::Real) = (λ / 2) * tr(𝔼)^2 + G * tr(𝔼^2)
+strain_energy_svk(𝔼::AbstractMatrix, λ::Real, G::Real) = (λ / 2) * tr(𝔼)^2 + G * tr(𝔼^2)
 λ, G = lame_parameters(svk)
 params = [λ, G] # The order must be the same defined in the strain energy(splatting)
 svk_hyper_elastic = HyperElastic(params, strain_energy_svk, "svkHyper")

--- a/examples/uniaxial_extension/uniaxial_extension.msh
+++ b/examples/uniaxial_extension/uniaxial_extension.msh
@@ -7,7 +7,7 @@ $PhysicalNames
 2 2 "_triangle_fixed-uj"
 2 3 "_triangle_fixed-uk"
 2 4 "_triangle_tension"
-3 5 "svk_tetrahedron_"
+3 5 "svkHyper_tetrahedron_"
 $EndPhysicalNames
 $Entities
 8 12 6 1

--- a/src/Elements/Tetrahedron.jl
+++ b/src/Elements/Tetrahedron.jl
@@ -92,7 +92,7 @@ end
 
 "Returns the internal force of a `Tetrahedron` element `t` doted with an `AbstractMaterial` `m` +
 and a an element displacement vector `u_e`."
-function internal_forces(f)
+function internal_forces(m::AbstractMaterial, t::Tetrahedron, u_e::AbstractVector)
 
   d = _shape_functions_derivatives(t)
 

--- a/src/Elements/Tetrahedron.jl
+++ b/src/Elements/Tetrahedron.jl
@@ -4,7 +4,7 @@ using LinearAlgebra: det, diagm
 using ..Materials: AbstractMaterial, SVK, cosserat
 using ..Elements: AbstractElement, AbstractNode
 using ..CrossSections: AbstractCrossSection, area
-using ..Utils: eye
+using ..Utils: eye, _vogit
 
 import ..Elements: create_entity, internal_forces, local_dof_symbol, strain, stress
 
@@ -90,12 +90,9 @@ function _B_mat(deriv::AbstractMatrix , 𝔽::AbstractMatrix)
   return B
 end
 
-_vogit(𝕋::AbstractMatrix, α::Real=1) = [𝕋[1,1],𝕋[2,2],𝕋[3,3],α*𝕋[2,3], α*𝕋[1,3], α*𝕋[1,2]]
-
-
 "Returns the internal force of a `Tetrahedron` element `t` doted with an `AbstractMaterial` `m` +
 and a an element displacement vector `u_e`."
-function internal_forces(m::AbstractMaterial, t::Tetrahedron, u_e::AbstractVector)
+function internal_forces(f)
 
   d = _shape_functions_derivatives(t)
 

--- a/src/Elements/Tetrahedron.jl
+++ b/src/Elements/Tetrahedron.jl
@@ -1,5 +1,5 @@
 using StaticArrays: SVector
-using LinearAlgebra: det, diagm
+using LinearAlgebra: Symmetric, det, diagm
 
 using ..Materials: AbstractMaterial, SVK, cosserat
 using ..Elements: AbstractElement, AbstractNode
@@ -112,11 +112,8 @@ function internal_forces(m::AbstractMaterial, t::Tetrahedron, u_e::AbstractVecto
   # Deformation gradient 
   𝔽 = ℍ + eye(3)
 
-  # Cauchy strain tensor
-  ℂ = 𝔽' * 𝔽 
-
   # Green-Lagrange strain  
-  𝔼 = 0.5 * (ℍ + ℍ' + ℍ' * ℍ)
+  𝔼 = Symmetric(0.5 * (ℍ + ℍ' + ℍ' * ℍ))
 
   𝕊, ∂𝕊∂𝔼 = cosserat(m, 𝔼)
 
@@ -127,12 +124,12 @@ function internal_forces(m::AbstractMaterial, t::Tetrahedron, u_e::AbstractVecto
   fᵢₙₜ_e = B' * 𝕊_vogit * vol
   
   # Material stiffness
-  Kₘ = B' * ∂𝕊∂𝔼 * B* vol
+  Kₘ = Symmetric(B' * ∂𝕊∂𝔼 * B* vol)
 
   # Geometric stiffness
   aux = funder' * 𝕊 * funder  * vol 
 
-  Kᵧ = zeros(12,12) 
+  Kᵧ = zeros(12,12) #TODO: Use Symmetriy and avoid indexes 
 
   for i in 1:4
     for j in 1:4
@@ -145,11 +142,13 @@ function internal_forces(m::AbstractMaterial, t::Tetrahedron, u_e::AbstractVecto
   # Stifness matrix
   Kᵢₙₜ_e = Kₘ + Kᵧ
 
+  # Compute stress and strian just for post-process
   # Piola stress
-  ℙ = 𝔽 * 𝕊
+  ℙ = Symmetric(𝔽 * 𝕊)
 
-  # Cuachy stress
-  # σ_e = ℙ
+  # Cauchy strain tensor
+  ℂ = Symmetric( 𝔽' * 𝔽 )
+
   
   return fᵢₙₜ_e, Kᵢₙₜ_e, ℙ, ℂ
 

--- a/src/Materials/HyperElastic.jl
+++ b/src/Materials/HyperElastic.jl
@@ -1,0 +1,66 @@
+using .Materials: AbstractMaterial
+using ..Utils: label, eye, _vogit
+using Tensors: SymmetricTensor, hessian
+
+import .Materials: density, parameters, cosserat, strain_energy
+
+export HyperElastic
+
+""" HyperElastic material struct.
+### Fields:
+- `params`         -- strain energy material parameters stored in a `Vector`.
+- `Ψ(𝔼,params...)` -- strain energy function given a `Vector` of parameters `params` and 
+                    the Green-Lagrange strain tensor `𝔼`.
+- `ρ`              -- density (`nothing` for static cases).
+- `label`          -- material label.
+
+[See this ref.](https://en.wikipedia.org/wiki/Hyperelastic_material)
+"""
+struct HyperElastic{T<:Real,F<:Function,R<:Union{T,Nothing}} <: AbstractMaterial
+    params::Vector{T}
+    Ψ::F
+    ρ::R
+    label::Symbol
+    function HyperElastic(params::Vector{T}, Ψ::F, ρ::R, label::L=:no_labelled_mat) where
+    {T<:Real,F<:Function,R<:Union{Nothing,Real},L<:Union{Symbol,String}}
+        return new{T,F,R}(params, Ψ, ρ, Symbol(label))
+    end
+end
+
+"Constructor for an `HyperElastic` material with no density parameter `ρ`."
+function HyperElastic(params::Vector{<:Real}, Ψ::Function, label::L=:no_labelled_mat) where {L<:Union{Symbol,String}}
+    return HyperElastic(params, Ψ, nothing, label)
+end
+
+
+"Returns the strain energy function `Ψ` for a `HyperElastic` material `m`."
+strain_energy(m::HyperElastic) = m.Ψ
+
+"Returns the strain energy parameters `params` for a `HyperElastic` material `m`."
+parameters(m::HyperElastic) = m.params
+
+"Returns the Cosserat or Second-Piola Kirchoff tensor (𝕊) considering an `HyperElastic`
+material `m` and the Lagrangian Green strain tensor `𝔼`."
+function cosserat(m::HyperElastic, 𝔼::AbstractMatrix)
+
+    𝔼 = SymmetricTensor{2,3}(𝔼)
+
+    # Closure strain energy function
+    Ψ = E -> strain_energy(m)(E, parameters(m)...)
+
+    ∂²Ψ∂E², 𝕊 = hessian(Ψ, 𝔼, :all)
+
+    # Fill ∂S∂𝔼 with Belischko nomenclature
+    ∂𝕊∂𝔼 = zeros(6, 6)
+    indexes = [(1, 1), (2, 2), (3, 3), (2, 3), (1, 3), (1, 2)]
+
+    row = 1
+    for index in indexes
+        i, j = index
+        ∂𝕊∂𝔼[row, :] .= _vogit(∂²Ψ∂E²[:, :, i, j])
+        row += 1
+    end
+
+    return 𝕊, ∂𝕊∂𝔼
+
+end

--- a/src/Materials/Materials.jl
+++ b/src/Materials/Materials.jl
@@ -8,9 +8,7 @@ using Reexport: @reexport
 
 @reexport import ..Utils: label
 
-export AbstractMaterial, density, parameters, cosserat, strain_energy,
-    elasticity_modulus, bulk_modulus, shear_modulus, poisson_ratio
-
+export AbstractMaterial, density, parameters, cosserat, strain_energy
 """ Abstract supertype for all material models.
 
 An `AbstractMaterial` object facilitates the process of defining new material models. 
@@ -18,51 +16,42 @@ Different material models leads to different constitutive laws, internal forces 
 
 **Common methods:**
 
-
 * [`strain_energy`](@ref)
 * [`parameters`](@ref)
 * [`density`](@ref)
-* [`bulk_modulus`](@ref)
-* [`elasticity_modulus`](@ref)
-* [`shear_modulus`](@ref)
-* [`poisson_ratio`](@ref)
 * [`cosserat`](@ref)
 * [`label`](@ref)
+
+**Common fields:**
+* label
+* ρ(density)
 """
 abstract type AbstractMaterial end
 
 "Returns the parameters of type `Number` in the `AbstractMaterial` `m`."
 parameters(m::T) where {T<:AbstractMaterial} = Tuple([getfield(f, n) for n in fieldlabels(T) if fieldtype(T, n) isa Number])
 
-"Returns the Cosserat or Second-Piola Kirchhoff stress tensor `𝕊``."
-function cosserat(m::AbstractMaterial) end
+"Returns the Cosserat or Second-Piola Kirchhoff stress tensor `𝕊` given an `AbstractMaterial` `m` and the 
+Green-Lagrange strain tensor `𝔼`."
+function cosserat(m::AbstractMaterial, 𝔼::AbstractMatrix) end
 
 "Returns the `AbstractMaterial` `m` density `ρ`."
-function density(m::AbstractMaterial) end
-
-"Returns the equivalent elasticity modulus `E` for the `AbstractMaterial` `m`."
-function elasticity_modulus(m::AbstractMaterial) end
-
-"Returns the equivalent Shear modulus `G` for the `AbstractMaterial` `m`."
-function shear_modulus(m::AbstractMaterial) end
-
-"Returns the equivalent Poisson's ratio `ν` for the `AbstractMaterial` `m`."
-function poisson_ratio(m::AbstractMaterial) end
-
-"Returns the equivalent Bulk modulus `K` for the `AbstractMaterial` `m`."
-function bulk_modulus(m::AbstractMaterial) end
+density(m::AbstractMaterial) = m.ρ
 
 "Returns the `AbstractMaterial` `m` label."
 label(m::AbstractMaterial) = m.label
 
-"Returns the `AbstractMaterial` `m` strain energy expression ϕ(𝔼) ."
-function strain_energy(m::AbstractMaterial) end
+"Returns the strain energy value for an `AbstractMaterial` `m`, and the Green-Lagrange 
+strain tensor `𝔼`."
+function strain_energy(m::AbstractMaterial, 𝔼) end
 
 #===================================#
 # AbstractMaterial implementations #
 #==================================#
 
 include("./SVK.jl")
+include("./HyperElastic.jl")
+
 # include("./NeoHookean.jl")
 
 end # module

--- a/src/Materials/SVK.jl
+++ b/src/Materials/SVK.jl
@@ -2,12 +2,11 @@ using LinearAlgebra: tr
 using SparseArrays: SparseMatrixCSC
 
 using .Materials: AbstractMaterial
-using ..Utils: label, eye
+using ..Utils: eye
 
-import .Materials: density, parameters, cosserat, strain_energy, elasticity_modulus,
-    shear_modulus, bulk_modulus, poisson_ratio
+import .Materials: density, cosserat, strain_energy
+export SVK, lame_parameters, elasticity_modulus, shear_modulus, bulk_modulus, poisson_ratio
 
-export SVK, lame_parameters
 
 """ SVK material struct.
 ### Fields:
@@ -25,6 +24,9 @@ struct SVK{T<:Real,R<:Union{T,Nothing}} <: AbstractMaterial
     label::Symbol
     function SVK(λ::T, G::T, ρ::R, label::L=:no_labelled_mat) where
     {T<:Real,R<:Union{Nothing,Real},L<:Union{Symbol,String}}
+        if ρ isa Real
+            ρ > 0 || error("Density must be positive.")
+        end
         return new{T,R}(λ, G, ρ, Symbol(label))
     end
 end
@@ -47,16 +49,16 @@ function SVK(; E::Real, ν::Real, ρ::R=nothing, label::L=:no_labelled_mat) wher
 end
 
 "Returns the strain energy expression for a `SVK` material `m`."
-strain_energy(::SVK) = :(λ / 2 * tr(𝔼)^2 + G * tr(𝔼^2))
+function strain_energy(m::SVK, 𝔼)
+    λ, G = lame_parameters(m)
+    λ / 2 * tr(𝔼)^2 + G * tr(𝔼^2)
+end
 
 "Returns lamé parameters `λ` and `G` from a `SVK` material `m`."
 lame_parameters(m::SVK) = m.λ, m.G
 
 "Returns the shear modulus `G` from a `SVK` material `m`."
 shear_modulus(m::SVK) = m.G
-
-"Returns the density `ρ` from a `SVK` material `m`."
-density(m::SVK) = m.ρ
 
 "Returns the Poisson's ration `ν` form a `SVK` material `m`."
 function poisson_ratio(m::SVK)
@@ -78,20 +80,18 @@ end
 
 "Returns the Cosserat or Second-Piola Kirchoff tensor (𝕊) for a `Tetrahedron` element `t`
 considering a `SVK` material `m` and the Lagrangian Green strain tensor `𝔼`."
-function cosserat(m::SVK, 𝔼::AbstractMatrix, compute∂𝕊∂𝔼::Bool=true)
+function cosserat(m::SVK, 𝔼::AbstractMatrix)
 
     λ, G = lame_parameters(m)
     𝕊 = λ * tr(𝔼) * eye(3) + 2 * G * 𝔼
 
-    if compute∂𝕊∂𝔼
-        ∂𝕊∂𝔼 = SparseMatrixCSC(zeros(6, 6))
-        ∂𝕊∂𝔼[1:3, 1:3] = λ * ones(3, 3) + 2 * G * eye(3)
-        ∂𝕊∂𝔼[4:6, 4:6] = G * eye(3)
-        return 𝕊, ∂𝕊∂𝔼
-    else
-        return 𝕊
-    end
+    ∂𝕊∂𝔼 = SparseMatrixCSC(zeros(6, 6))
+    ∂𝕊∂𝔼[1:3, 1:3] = λ * ones(3, 3) + 2 * G * eye(3)
+    ∂𝕊∂𝔼[4:6, 4:6] = G * eye(3)
+
+    return 𝕊, ∂𝕊∂𝔼
 
 end
+
 
 

--- a/src/Materials/SVK.jl
+++ b/src/Materials/SVK.jl
@@ -78,8 +78,8 @@ function bulk_modulus(m::SVK)
     return λ + 2 * G / 3
 end
 
-"Returns the Cosserat or Second-Piola Kirchoff tensor (𝕊) for a `Tetrahedron` element `t`
-considering a `SVK` material `m` and the Lagrangian Green strain tensor `𝔼`."
+"Returns the Cosserat or Second-Piola Kirchoff tensor `𝕊` considering a `SVK` material `m` 
+and the Lagrangian Green strain tensor `𝔼`."
 function cosserat(m::SVK, 𝔼::AbstractMatrix)
 
     λ, G = lame_parameters(m)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -33,4 +33,8 @@ eye(m::Integer, T=Bool) = Diagonal(ones(T, m))
 "Transforms a vector of vectors into a 1D row vector."
 row_vector(v::Vector{<:AbstractVector{T}}) where {T} = reduce(vcat, v)
 
+"Returns the Voigt notation of tensor `𝕋`."
+_vogit(𝕋::AbstractMatrix, α::Real=1) = [𝕋[1, 1], 𝕋[2, 2], 𝕋[3, 3], α * 𝕋[2, 3], α * 𝕋[1, 3], α * 𝕋[1, 2]]
+
+
 end # module

--- a/test/test_Materials.jl
+++ b/test/test_Materials.jl
@@ -3,9 +3,12 @@
 ##########################
 using Test: @testset, @test
 using ONSAS.Materials
+using LinearAlgebra: Symmetric, tr
 const RTOL = 1e-3
 
-@testset "ONSAS.Materials SVK" begin
+strain_energy_svk(𝔼, λ::Real, G::Real) = (λ / 2) * tr(𝔼)^2 + G * tr(𝔼^2)
+
+@testset "ONSAS.Materials.SVK" begin
 
     # Steel 
     E = 210e9
@@ -16,6 +19,7 @@ const RTOL = 1e-3
 
     # SVK for static analysis
     svk_static = SVK(λ, G)
+
     @test lame_parameters(svk_static) == (λ, G)
     @test density(svk_static) == nothing
     @test elasticity_modulus(svk_static) ≈ E rtol = RTOL
@@ -31,7 +35,63 @@ const RTOL = 1e-3
     @test lame_parameters(svk_dynamic)[1] ≈ λ rtol = RTOL
     @test lame_parameters(svk_dynamic)[2] ≈ G rtol = RTOL
 
-    @test strain_energy(svk_dynamic) == :((λ / 2) * tr(𝔼)^2 + G * tr(𝔼^2))
+    𝔼 = Symmetric(rand(3, 3))
+
+    @test strain_energy(svk_dynamic, 𝔼) == strain_energy_svk(𝔼, lame_parameters(svk_static)...)
     @test label(svk_dynamic) == Symbol(label_lame)
+
+end
+
+
+@testset "ONSAS.Materials.HyperElastic(SVK)" begin
+
+    λ = 0.5769
+    G = μ = 0.3846
+
+    𝕊_test = Symmetric(
+        [
+            1.15596 0.224991 0.392292
+            0.224991 1.34922 0.553824
+            0.392292 0.553824 1.89151
+        ]
+    )
+
+    ∂𝕊∂𝔼_test = [
+        1.3461 0.5769 0.5769 0.0 0.0 0.0
+        0.5769 1.3461 0.5769 0.0 0.0 0.0
+        0.5769 0.5769 1.3461 0.0 0.0 0.0
+        0.0 0.0 0.0 0.3846 0.0 0.0
+        0.0 0.0 0.0 0.0 0.3846 0.0
+        0.0 0.0 0.0 0.0 0.0 0.3846
+    ]
+
+
+    𝔼 = Symmetric(
+        [
+            0.18375 0.2925 0.51
+            0.2925 0.435 0.72
+            0.51 0.72 1.14
+        ]
+    )
+
+    svk = SVK(λ, G)
+    # Create a generic HyperElastic material with an SVK   
+    l = "svk_HyperElastic"
+    svk_hyper = HyperElastic([λ, G], strain_energy_svk, l)
+
+    @test parameters(svk_hyper) == [λ, G]
+    @test density(svk_hyper) == nothing
+    @test label(svk_hyper) == Symbol(l)
+
+    # Constitutive driver svk type SVK
+    𝕊_svk, ∂𝕊∂𝔼_svk = cosserat(svk, 𝔼)
+
+    @test 𝕊_svk ≈ 𝕊_test rtol = RTOL
+    @test ∂𝕊∂𝔼_svk ≈ ∂𝕊∂𝔼_test rtol = RTOL
+
+    𝕊_hyper, ∂𝕊∂𝔼_hyper = cosserat(svk_hyper, 𝔼)
+
+    @test 𝕊_hyper ≈ 𝕊_test rtol = RTOL
+    @test ∂𝕊∂𝔼_svk ≈ ∂𝕊∂𝔼_test rtol = RTOL
 
 end

--- a/test/test_Meshes.jl
+++ b/test/test_Meshes.jl
@@ -75,13 +75,13 @@ end
     @test nodes(msh_file) == msh_file.vec_nodes
     @test length(physical_index(msh_file)) == length(connectivity(msh_file))
     @test dimension(msh_file) == dimension(first(nodes(msh_file)))
-    @test material_label(msh_file) == ["", "", "", "", "svk"]
+    @test material_label(msh_file) == ["", "", "", "", "svkHyper"]
     @test entity_label(msh_file) == ["triangle", "triangle", "triangle", "triangle", "tetrahedron"]
     @test bc_label(msh_file) == ["fixed-ux", "fixed-uj", "fixed-uk", "tension", ""]
 
     entity_index = 100
     @test entity_label(msh_file, entity_index) == "tetrahedron"
-    @test material_label(msh_file, entity_index) == "svk"
+    @test material_label(msh_file, entity_index) == "svkHyper"
     @test bc_label(msh_file, entity_index) == ""
     @test physical_index(msh_file, entity_index) == 5
 

--- a/uniaxial_extension.msh
+++ b/uniaxial_extension.msh
@@ -1,0 +1,6 @@
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 0
+$EndEntities


### PR DESCRIPTION
Closes #122
Addressing #89 

A new `HyperElastic` materia case is added into the uniaxial-extension example. 

```julia
# -------------------------------
# Materials
# -------------------------------
# Define a new HyperElastic material from the strain energy function
strain_energy_svk(𝔼::AbstractMatrix, λ::Real, G::Real) = (λ / 2) * tr(𝔼)^2 + G * tr(𝔼^2)
λ, G = lame_parameters(svk)
params = [λ, G] # The order must be the same defined in the strain energy(splatting)
svk_hyper_elastic = HyperElastic(params, strain_energy_svk, "svkHyper")
# Material types without assigned elements
mat_types = [svk_hyper_elastic]
s_materials = StructuralMaterials(mat_types)

```