### PR TITLE
Validates linear extension stresses and strains

### DIFF
--- a/examples/linear_extension/linear_extension.jl
+++ b/examples/linear_extension/linear_extension.jl
@@ -182,6 +182,6 @@ p_rand_e = rand(coordinates(e_rand))
     @test norm(ϵₖ_numeric_e_rand) ≈ 0 atol = RTOL
     # Stresses 
     @test σᵢ_analytic_p_rand_e ≈ σᵢ_analytic_p_rand_e rtol = RTOL
-    @test norm(σⱼ_analytic_p_rand_e) ≈ σⱼ_analytic_p_rand_e atol = RTOL
-    @test norm(σₖ_analytic_p_rand_e) ≈ σₖ_analytic_p_rand_e atol = RTOL
+    @test σⱼ_analytic_p_rand_e ≈ σⱼ_analytic_p_rand_e atol = RTOL
+    @test σₖ_analytic_p_rand_e ≈ σₖ_analytic_p_rand_e atol = RTOL
 end

--- a/src/Elements/Tetrahedron.jl
+++ b/src/Elements/Tetrahedron.jl
@@ -179,14 +179,14 @@ function internal_forces(m::IsotropicLinearElastic, t::Tetrahedron, u_e::Abstrac
   U = reshape(u_e, 3, 4)
   ℍ = U * funder'
   
-  ϵ = Symmetric(0.5 * (ℍ + ℍ' + ℍ' * ℍ))
+  ϵ = Symmetric(0.5 * (ℍ + ℍ'))
   𝔽 = eye(3)
 
   B = _B_mat(funder, 𝔽)
 
-  σ, ∂σ∂𝔼 = cauchy_stress(m, ϵ)
+  σ, ∂σ∂ϵ = cauchy_stress(m, ϵ)
 
-  Kᵢₙₜ_e = Symmetric(B' * ∂σ∂𝔼 * B* vol)
+  Kᵢₙₜ_e = Symmetric(B' * ∂σ∂ϵ * B* vol)
   
   fᵢₙₜ_e = Kᵢₙₜ_e * u_e
 


### PR DESCRIPTION
This was done with @jorgepz. The error was that for linear cases the strain tensor is `1/2( ∇u +∇u')`

Closes #167 