### PR TITLE
Fixed `reset!` function 

### DIFF
--- a/benchmark/bench_recomplilation.jl
+++ b/benchmark/bench_recomplilation.jl
@@ -1,0 +1,76 @@
+using BenchmarkTools, ONSAS, Suppressor, StaticArrays
+
+# Utils
+include("bench_utils.jl")
+
+"Print the time to build the structure, define the analysis and solve the analysis."
+function print_times(t_structure, t_problem, t_solve, t_point_eval_handler, t_eval_sol)
+    @info "Time to build the structure: $t_structure"
+    @info "Time to define the analysis: $t_problem"
+    @info "Time to solve the analysis: $t_solve"
+    @info "Time to build the point evaluation handler: $t_point_eval_handler"
+    @info "Time to evaluate the solution: $t_eval_sol"
+end
+
+"Runs the experiment and prints the times."
+function run_experiment(
+    build_structure::Function,
+    analysis,
+    alg::AbstractSolver;
+    ms, NSTEPS, N_POINTS_EVAL)
+
+    structure, t_structure, _ = @timed build_structure(; ms)
+
+    problem, t_problem = @timed analysis(structure, NSTEPS=NSTEPS)
+    reset!(problem)
+
+    solution, t_solve, _ = @timed solve!(problem, alg)
+
+    ph, t_point_eval_handler, _ = @timed PointEvalHandler(structure, [SVector(rand(3)...) for i in 1:N_POINTS_EVAL])
+    _, t_eval_sol, _ = @timed displacements(solution, ph)
+
+    return t_structure, t_problem, t_solve, t_point_eval_handler, t_eval_sol
+end
+
+# Alg to solve static problems
+tols = ConvergenceSettings(rel_U_tol=1e-8, rel_res_force_tol=1e-6, max_iter=20);
+alg = NewtonRaphson(tols);
+# Static analysis number of steps to reach the final load factor value
+NSTEPS = 8;
+# Refinement factor 
+ms = 0.5;
+# Number of points to evaluate the solution
+N_POINTS_EVAL = 100;
+
+# ===============================================================
+# Uniaxial compression.
+# ===============================================================
+example_name = "uniaxial_compression";
+example_folder, bench_path = joinpath_example_folder(example_name);
+include(bench_path);
+
+# Compilation time 
+times_compilation = run_experiment(
+    uniaxial_compression_structure, NonLinearStaticAnalysis, alg;
+    ms=ms, NSTEPS=NSTEPS, N_POINTS_EVAL=N_POINTS_EVAL
+);
+
+println("Compiling 🚧...")
+print_times(times_compilation...)
+
+# First experiment
+times₁ = run_experiment(
+    uniaxial_compression_structure, NonLinearStaticAnalysis, alg;
+    ms=ms, NSTEPS=NSTEPS, N_POINTS_EVAL=N_POINTS_EVAL
+);
+println("Experiment 1 🔨...")
+print_times(times₁...)
+
+# Second experiment
+times₂ = run_experiment(
+    uniaxial_compression_structure, NonLinearStaticAnalysis, alg;
+    ms=ms, NSTEPS=NSTEPS, N_POINTS_EVAL=N_POINTS_EVAL
+);
+println("Experiment 2 🔨")
+print_times(times₂...)
+

--- a/benchmark/uniaxial_compression/bench_recomplilation.jl
+++ b/benchmark/uniaxial_compression/bench_recomplilation.jl
@@ -1,7 +1,7 @@
 using BenchmarkTools, ONSAS, Suppressor, StaticArrays
 
 # Utils
-include("bench_utils.jl")
+include("./../bench_utils.jl")
 
 "Print the time to build the structure, define the analysis and solve the analysis."
 function print_times(t_structure, t_problem, t_solve, t_point_eval_handler, t_eval_sol)
@@ -54,8 +54,7 @@ times_compilation = run_experiment(
     uniaxial_compression_structure, NonLinearStaticAnalysis, alg;
     ms=ms, NSTEPS=NSTEPS, N_POINTS_EVAL=N_POINTS_EVAL
 );
-
-println("Compiling 🚧...")
+println("Compiling 🚧:")
 print_times(times_compilation...)
 
 # First experiment
@@ -63,7 +62,7 @@ times₁ = run_experiment(
     uniaxial_compression_structure, NonLinearStaticAnalysis, alg;
     ms=ms, NSTEPS=NSTEPS, N_POINTS_EVAL=N_POINTS_EVAL
 );
-println("Experiment 1 🔨...")
+println("Experiment 1 🔨:")
 print_times(times₁...)
 
 # Second experiment
@@ -71,6 +70,7 @@ times₂ = run_experiment(
     uniaxial_compression_structure, NonLinearStaticAnalysis, alg;
     ms=ms, NSTEPS=NSTEPS, N_POINTS_EVAL=N_POINTS_EVAL
 );
-println("Experiment 2 🔨")
+println("Experiment 2 🔨:")
 print_times(times₂...)
 
+delete_files(example_folder, ".msh");

--- a/src/StructuralAnalyses/StaticAnalyses.jl
+++ b/src/StructuralAnalyses/StaticAnalyses.jl
@@ -74,16 +74,22 @@ current_load_factor(sa::AbstractStaticAnalysis) = current_time(sa)
 "Jumps to the next current load factor defined in the `AbstractStaticAnalysis` `sa`."
 _next!(sa::AbstractStaticAnalysis) = sa.current_step[] += 1
 
-"Sets the current load factor of the `AbstractStaticAnalysis` `sa` to the initial load factor."
-reset!(sa::AbstractStaticAnalysis) = sa.current_step[] = 1
+"Sets the current load factor of the `AbstractStaticAnalysis` `sa` to the initial load factor.
+Also resets! the iteration and `AbstractStructuralState`."
+function reset!(sa::AbstractStaticAnalysis)
+    sa.current_step[] = 1
+    reset!(current_state(sa))
+    @info "The current time of analysis have been reset."
+    sa
+end
 
 "Assembles the Structure `s` (internal forces) during the `StaticAnalysis` `sa`."
 function _assemble!(s::AbstractStructure, sa::AbstractStaticAnalysis)
 
     state = current_state(sa)
 
-    # Reset assembler
-    _reset!(state)
+    # Reset assembled magnitudes
+    _reset_assemble!(state)
 
     for (mat, mat_elements) in pairs(materials(s))
         for e in mat_elements
@@ -106,6 +112,14 @@ function _assemble!(s::AbstractStructure, sa::AbstractStaticAnalysis)
 
 end
 
+"Resets the assembled magnitudes of the `AbstractStructuralState` `state`."
+function _reset_assemble!(state::AbstractStructuralState)
+    _reset!(assembler(state))
+    internal_forces(state) .= 0.0
+    tangent_matrix(state)[findall(!iszero, tangent_matrix(state))] .= 0.0
+    # FIXME: Zero out stress and strain
+    nothing
+end
 
 "Pushes the current state `c_state` into the `StatesSolution` `st_sol`."
 function Base.push!(st_sol::StatesSolution, c_state::StaticState)

--- a/src/StructuralAnalyses/StructuralAnalyses.jl
+++ b/src/StructuralAnalyses/StructuralAnalyses.jl
@@ -17,7 +17,7 @@ using Reexport: @reexport
 
 import ..Elements: internal_forces, inertial_forces, strain, stress
 import ..StructuralModel: free_dofs
-import ..StructuralSolvers: _assemble!, _update!, _reset!, _end_assemble!
+import ..StructuralSolvers: _assemble!, _update!, _end_assemble!
 @reexport import ..StructuralSolvers: displacements, external_forces, iteration_residuals
 
 export AbstractStructuralState, _apply!, _assemble!, Δ_displacements, tangent_matrix, residual_forces,
@@ -49,8 +49,6 @@ export AbstractStructuralAnalysis, initial_time, current_time, final_time, _next
 * [`residual_displacements_norms`](@ref)
 """
 abstract type AbstractStructuralState end
-
-#Accessors
 
 "Returns the `Assembler` used in the `AbstractStructuralState` `st`."
 assembler(st::AbstractStructuralState) = st.assembler
@@ -96,8 +94,8 @@ _assemble!(st::AbstractStructuralState, kₛ_e::AbstractMatrix, e::AbstractEleme
 
 "Assembles the element `e` stress σₑ and strain ϵₑ into the `AbstractState` `st`"
 function _assemble!(st::AbstractStructuralState, σₑ::E, ϵₑ::E, e::AbstractElement) where {E<:Union{Real,AbstractMatrix}}
-    stress(st)[e] = σₑ
-    strain(st)[e] = ϵₑ
+    stress(st)[e] .= σₑ
+    strain(st)[e] .= ϵₑ
 end
 
 "Fill the system tangent matrix in the `AbstractStructuralState` `st` once the `Assembler` object is built."
@@ -110,21 +108,21 @@ function tangent_matrix(st::AbstractStructuralState, alg::AbstractSolver) end
 function residual_forces_norms(st::AbstractStructuralState)
     rᵏ_norm = residual_forces(st) |> norm
     fₑₓₜ_norm = external_forces(st) |> norm
-    return rᵏ_norm, rᵏ_norm / fₑₓₜ_norm
+    rᵏ_norm, rᵏ_norm / fₑₓₜ_norm
 end
 
 "Returns relative residual displacements for the current `AbstractStructuralState` `st`."
 function residual_displacements_norms(st::AbstractStructuralState)
     ΔU_norm = Δ_displacements(st) |> norm
     U_norm = displacements(st) |> norm
-    return ΔU_norm, ΔU_norm / U_norm
+    ΔU_norm, ΔU_norm / U_norm
 end
 
 "Updates the `AbstractStructuralState` `st` during the displacements iteration."
 function _update!(st::AbstractStructuralState, args...; kwargs...) end
 
 "Resets  the `AbstractStructuralState` assembled magnitudes before starting a new assembly."
-function _reset!(st::AbstractStructuralState, args...; kwargs...) end
+function reset!(st::AbstractStructuralState, args...; kwargs...) end
 
 """ Abstract supertype for all structural analysis.
 
@@ -183,13 +181,10 @@ function reset!(a::AbstractStructuralState) end
 
 "Applies an `AbstractLoadBoundaryCondition` lbc into the structural analysis `sa` at the current analysis time `t`"
 function _apply!(sa::AbstractStructuralAnalysis, lbc::AbstractLoadBoundaryCondition)
-
     t = current_time(sa)
     bcs = boundary_conditions(structure(sa))
     dofs_lbc, dofs_values = _apply(bcs, lbc, t)
-
     external_forces(current_state(sa))[dofs_lbc] = dofs_values
-
 end
 
 "Applies a vector of load boundary conditions to the structure `s` "

--- a/test/test_StaticAnalyses.jl
+++ b/test/test_StaticAnalyses.jl
@@ -118,12 +118,16 @@ sst_rand = StaticState(s, ΔUᵏ, Uᵏ, Fₑₓₜᵏ, Fᵢₙₜᵏ, Kₛᵏ, �
     @test displacements(sst_rand) == Uᵏ⁺¹
 
     # Reset the assembled magnitudes
-    _reset!(sst_rand)
+    reset!(sst_rand)
     @test isempty(assembler(sst_rand).V)
     @test isempty(assembler(sst_rand).I)
     @test isempty(assembler(sst_rand).J)
     @test iszero(internal_forces(sst_rand))
     @test iszero(tangent_matrix(sst_rand))
+    @test iszero(displacements(sst_rand))
+    @test iszero(Δ_displacements(sst_rand))
+    @test all([iszero(strain(sst_rand)[e]) for e in elements(s)])
+    @test all([iszero(stress(sst_rand)[e]) for e in elements(s)])
 
     # Default static analysis of the structure 
     default_s = StaticState(s)
@@ -149,7 +153,6 @@ sst_rand = StaticState(s, ΔUᵏ, Uᵏ, Fₑₓₜᵏ, Fᵢₙₜᵏ, Kₛᵏ, �
     _assemble!(default_s, σ_e_2, ϵ_e_2, truss₂)
     # End assemble 
     _end_assemble!(default_s)
-
 
     # Manufactured assemble 
     Fᵢₙₜ = zeros(9)


### PR DESCRIPTION
Now both `AbstractStructuralAnalysis` and `AbstractStructuralState` and fully reset and tested. 

A simple experiment is added in benchmark_recompilation.jl using this feature. 

Resutls `ms=.5` `NPOINTS_roi = 100` :
```julia
Compiling 🚧:
[ Info: Time to build the structure: 6.095110645
[ Info: Time to define the analysis: 0.558063118
[ Info: Time to solve the analysis: 19.703809605
[ Info: Time to build the point evaluation handler: 0.787992651
[ Info: Time to evaluate the solution: 1.188223334
[ Info: The structural state has been reset.
[ Info: The current time of analysis have been reset.

Experiment 1 🔨:
[ Info: Time to build the structure: 0.0182878
[ Info: Time to define the analysis: 0.000175101
[ Info: Time to solve the analysis: 1.184625518
[ Info: Time to build the point evaluation handler: 0.002915541
[ Info: Time to evaluate the solution: 0.003113634

Experiment 2 🔨:
[ Info: Time to build the structure: 0.019445983
[ Info: Time to define the analysis: 0.000181615
[ Info: Time to solve the analysis: 1.187585407
[ Info: Time to build the point evaluation handler: 0.002024724
[ Info: Time to evaluate the solution: 0.002473282
[ Info: The structural state has been reset.
[ Info: The current time of analysis has been reset.

```

Closes #132 
Addressing #183 
