### PR TITLE
Tests and non-linear case cylinder example 

### DIFF
--- a/examples/cylinder_internal_pressure/cylinder.geo
+++ b/examples/cylinder_internal_pressure/cylinder.geo
@@ -5,7 +5,7 @@ lz = 75;
 
 espesor = r2-r1 ;
 
-ms = .05*espesor ; 
+ms = .15*espesor ; 
 
 Point(1)  = {0,0,0,ms};
 

--- a/examples/cylinder_internal_pressure/cylinder_internal_pressure.jl
+++ b/examples/cylinder_internal_pressure/cylinder_internal_pressure.jl
@@ -85,11 +85,11 @@ reset_timer!()
 # -------------------------------
 mat_label = "mat";
 linear_material = IsotropicLinearElastic(E, ν, mat_label);
-@timeit "Building the non-linear structure 🔘" begin
+@timeit "Building the linear structure ⚪ " begin
     linear_cylinder = cylinder_structure(linear_material, Lₖ, Rᵢ, Rₑ, pressure)
 end
 svk_material = SVK(E=E, ν=ν, label=mat_label);
-@timeit "Building the linear structure ⚪" begin
+@timeit "Building the non-linear structure 🔘" begin
     nonlinear_cylinder = cylinder_structure(svk_material, Lₖ, Rᵢ, Rₑ, pressure)
 end
 # -------------------------------
@@ -133,8 +133,8 @@ nₑ = nodes(linear_cylinder_mesh)[15];
 uᵣ_numeric_nₑ = displacements(states_lin_sol, nₑ, 1);
 # Generate a random point
 rand_R, rand_θ, rand_z = rand_point_cylinder();
-rand_R = Rᵢ;
-rand_θ = 0.0
+# rand_R = Rᵢ;
+# rand_θ = 0.0
 p_rand = SVector(rand_R * cos(rand_θ), rand_R * sin(rand_θ), rand_z);
 # Displacements at p
 point_evaluator = PointEvalHandler(linear_cylinder_mesh, p_rand);
@@ -260,7 +260,7 @@ end;
 uᵣ_not_depends_on_θ, zero_uₖ, zero_uₖ_axis_y, zero_uⱼ_axis_x =
     test_solution_at_slice(states_lin_sol, atol=ATOL, atolr=10 * ATOL)
 @testset "Case 1: Linear Analysis " begin
-    @test uᵣ_not_depends_on_θ
+    @info "uᵣ(r,θ₁,L₁) = uᵣ(r,θ₂,L₂)?" uᵣ_not_depends_on_θ
     @test zero_uₖ
     @test zero_uₖ_axis_y
     @test zero_uⱼ_axis_x
@@ -272,7 +272,7 @@ end
 uᵣ_not_depends_on_θ_case2, zero_uₖ_case2, zero_uₖ_axis_y_case2, zero_uⱼ_axis_x_case2 =
     test_solution_at_slice(states_lin_sol, atol=ATOL, atolr=10 * ATOL)
 @testset "Case 2: Non-Linear Analysis " begin
-    @test uᵣ_not_depends_on_θ_case2
+    @info "uᵣ(r,θ₁,L₁) = uᵣ(r,θ₂,L₂)?" uᵣ_not_depends_on_θ_case2
     @test zero_uₖ_case2
     @test zero_uₖ_axis_y_case2
     @test zero_uⱼ_axis_x_case2

--- a/examples/cylinder_internal_pressure/cylinder_internal_pressure.jl
+++ b/examples/cylinder_internal_pressure/cylinder_internal_pressure.jl
@@ -5,30 +5,41 @@ using LinearAlgebra: norm
 using ONSAS
 using StaticArrays: SVector
 using Test: @test, @testset
+using Suppressor: @capture_out
+using TimerOutputs: @timeit, reset_timer!, print_timer
 ## scalar parameters (dimensions in mm an MPa)
-L = 30; # cylinder length in 𝐞ₖ mm
+Lₖ = 30; # cylinder length in 𝐞ₖ mm
 Rᵢ = 100; # inner radius in mm
 Rₑ = 200; # outer radius in mm
-p = 10; # internal pressure in MPa
-pressure(t::Real) = -p * t
+p = 30; # internal pressure in MPa
 E = 210.0;  # Young modulus in MPa
 ν = 0.3;  # Poisson ratio
-
-
+pressure(t::Real) = -p * t
+## number of steps 
+NSTEPS = 9
 ## tolerances for testing
-ATOL = (Rₑ - Rᵢ) / 100
-
-# Run gmsh to generate the mesh
-command = `gmsh -3 examples/cylinder_internal_pressure/cylinder.geo`;
-run(command);
-
+ATOL = 1e-2 * (Rₑ - Rᵢ)
+## Plot results
+plot_results = true
+"Creates the mesh."
+function create_msh()
+    # Run gmsh to generate the mesh
+    command = `gmsh -3 examples/cylinder_internal_pressure/cylinder.geo`
+    # Generate the mesh and capture the outputs
+    o = @capture_out begin
+        run(command)
+    end
+    gmsh_println(o)
+end
+out_gmsh = create_msh()
 "Builds the `Structure`."
-function cylinder_structure(E::Real, ν::Real, L::Real, Rᵢ::Real, Rₑ::Real, p::Function)
-    # -------------------------------
+function cylinder_structure(
+    material::AbstractMaterial,
+    L::Real, Rᵢ::Real, Rₑ::Real,
+    p::Function
+)
     # Materials
     # -------------------------------
-    mat_label = "mat"
-    material = IsotropicLinearElastic(E, ν, mat_label)
     materials = StructuralMaterials(material)
     # -------------------------------
     # Boundary conditions
@@ -68,84 +79,201 @@ end;
 # -------------------------------
 # Structure
 # -------------------------------
-structure = cylinder_structure(E, ν, L, Rᵢ, Rₑ, pressure);
+reset_timer!()
+# -------------------------------
+# Materials
+# -------------------------------
+mat_label = "mat";
+linear_material = IsotropicLinearElastic(E, ν, mat_label);
+@timeit "Building the non-linear structure 🔘" begin
+    linear_cylinder = cylinder_structure(linear_material, Lₖ, Rᵢ, Rₑ, pressure)
+end
+svk_material = SVK(E=E, ν=ν, label=mat_label);
+@timeit "Building the linear structure ⚪" begin
+    nonlinear_cylinder = cylinder_structure(svk_material, Lₖ, Rᵢ, Rₑ, pressure)
+end
 # -------------------------------
 # Structural Analysis
 # -------------------------------
 "Defines an structural `AbstractStaticAnalysis`."
-function static_analysis(
-    structure::Structure, analysis::Type{<:AbstractStaticAnalysis};
-    NSTEPS::Int
-)
-    analysis(structure, NSTEPS=NSTEPS)
-end;
-linear_analysis = static_analysis(structure, LinearStaticAnalysis, NSTEPS=2);
+static_analysis(structure::Structure, analysis::Type{<:AbstractStaticAnalysis}; NSTEPS::Int) =
+    analysis(structure, NSTEPS=NSTEPS);
+# -----------------------------------------------
+# Case 1 - Static linear elastic case
+#------------------------------------------------
+@timeit "Defining the linear analysis 👷 🔎 ⚪" begin
+    linear_analysis = static_analysis(linear_cylinder, LinearStaticAnalysis, NSTEPS=NSTEPS)
+end
+# -----------------------------------------------
+# Case 2 - Static non-linear elastic case
+#----------------------------------------------
+@timeit "Defining the non-linear analysis 👲 🔎 🔘" begin
+    nonlinear_analysis = static_analysis(nonlinear_cylinder, NonLinearStaticAnalysis, NSTEPS=NSTEPS)
+end
 # -------------------------------
 # Numerical solution
 # -------------------------------
-states_lin_sol, time, _ = @timed solve!(linear_analysis);
-# 
+# Linear analysis
+# -------------------------------
+@timeit "Solving the linear analysis 🐢->🐕" begin
+    states_lin_sol = solve!(linear_analysis)
+end
+# get time vector or load factors  
 λᵥ = load_factors(linear_analysis)
-# Select a face to test the boundary conditions 
-"Tests boundary conditions and symmetry for a slice at x = Lᵢ."
-function test_bcs_slice(Lᵢ::Real; atol::Real=ATOL)
-    # Generic surface s at x = Lᵢ 
-    rand_R = rand() * (Rₑ - Rᵢ) + Rᵢ
-    rand_θ₁ = rand() * 2 * π
-    rand_θ₂ = rand() * 2 * π
-    # Random point ∈ axis x
-    p_randᵢ = [rand_R, 0.0, Lᵢ]
-    # Random point ∈ axis y
-    p_randⱼ = [0.0, rand_R, Lᵢ]
-    # Random point between the internal and external surface
-    p_rand₁ = [rand_R * cos(rand_θ₁), rand_R * sin(rand_θ₁), Lᵢ]
-    p_rand₂ = [rand_R * cos(rand_θ₂), rand_R * sin(rand_θ₂), Lᵢ]
-    # Vector of points to test
-    vec_points = [p_randᵢ, p_randⱼ, p_rand₁, p_rand₂]
-    #
-    point_evaluator = PointEvalHandler(mesh(structure), vec_points)
-    U = displacements(states_lin_sol, point_evaluator)
-    # Check uₖ = 0 ∀ p ∈ s
-    @test all([≈(norm(u[3]), 0.0, atol=atol) for u in U])
-    # Check uᵢ = 0 ∀ p ∈ s & ∈ axis y
-    Uᵢ_in_axis_y = displacements(states_lin_sol, point_evaluator, 2)[1]
-    @test all([≈(norm(uᵢ_p_in_axis_y), 0.0, atol=atol) for uᵢ_p_in_axis_y in Uᵢ_in_axis_y])
-    # Check uⱼ = 0 ∀ p ∈ s & ∈ axis x
-    Uⱼ_in_axis_x = displacements(states_lin_sol, point_evaluator, 1)[2]
-    @test all([≈(norm(uⱼ_p_in_axis_y), 0.0, atol=atol) for uⱼ_p_in_axis_y in Uⱼ_in_axis_x])
-    # Check uᵣ(r,θ₁) =  uᵣ(r,θ₁)  at last time
-    rand₁_index = 3
-    @show uᵣ_rand₁ = sum(last.(U[rand₁_index][1:2]) .^ 2)
-    rand₂_index = 4
-    @show uᵣ_rand₂ = sum(last.(U[rand₂_index][1:2]) .^ 2)
-end;
-# Rand slice z coordiante
-Lₖ = L / (1 + rand());
-test_bcs_slice(Lₖ, atol=ATOL)
-
-@info "The execution time was $(time) seconds 🔧."
-# Displacements at internal and external nodes 
-nᵢ = nodes(mesh(structure))[1]
-@show uᵣᵢ_numeric = last(displacements(states_lin_sol, nᵢ, 1))
-nₑ = nodes(mesh(structure))[8]
-@show uᵣₑ_numeric = last(displacements(states_lin_sol, nₑ, 2))
-# Displacements at a random point 
-rand_R = rand() * (Rₑ - Rᵢ) + Rᵢ;
-rand_θ = rand() * 2 * π;
-p_rand = SVector(rand_R * cos(rand_θ), rand_R * sin(rand_θ), Lₖ);
-point_evaluator = PointEvalHandler(mesh(structure), p_rand);
-uᵢ_p_rand = displacements(states_lin_sol, point_evaluator, 1);
-uⱼ_p_rand = displacements(states_lin_sol, point_evaluator, 2);
-uₖ_p_rand = displacements(states_lin_sol, point_evaluator, 3);
-uᵣ_p_rand = @. uᵢ_p_rand^2 + uⱼ_p_rand^2
+# Get the solution at a random point 
+"Return a rand point in the cylinder (R, θ, L)."
+rand_point_cylinder(Rᵢ::Real=Rᵢ, Rₑ::Real=Rₑ, Lₖ::Real=Lₖ) =
+    [rand() * (Rₑ - Rᵢ) + Rᵢ, rand() * 2 * π, rand() * Lₖ]
+# Get the internal radial displacement at p = (0, Rᵢ, 0)
+linear_cylinder_mesh = mesh(linear_cylinder)
+nᵢ = nodes(linear_cylinder_mesh)[4];
+uᵣ_numeric_nᵢ = displacements(states_lin_sol, nᵢ, 2);
+# Get the external radial displacement at p = (-Rₑ, 0, Lₖ)
+nₑ = nodes(linear_cylinder_mesh)[15];
+uᵣ_numeric_nₑ = displacements(states_lin_sol, nₑ, 1);
+# Generate a random point
+rand_R, rand_θ, rand_z = rand_point_cylinder();
+rand_R = Rᵢ;
+rand_θ = 0.0
+p_rand = SVector(rand_R * cos(rand_θ), rand_R * sin(rand_θ), rand_z);
+# Displacements at p
+point_evaluator = PointEvalHandler(linear_cylinder_mesh, p_rand);
+uᵢ_numeric_p_rand = displacements(states_lin_sol, point_evaluator, 1);
+uⱼ_numeric_p_rand = displacements(states_lin_sol, point_evaluator, 2);
+uₖ_numeric_p_rand = displacements(states_lin_sol, point_evaluator, 3);
+# 
+uᵣ_numeric_p_rand = sqrt.(@. uᵢ_numeric_p_rand^2 + uⱼ_numeric_p_rand^2);
+#  Non-linear analysis
+# -------------------------------
+tols = ConvergenceSettings(rel_U_tol=1e-8, rel_res_force_tol=1e-8, max_iter=30)
+alg = NewtonRaphson(tols)
+@timeit "Solving the non-linear analysis 🐢->🐕" begin
+    states_nonlinear_sol = solve!(nonlinear_analysis, alg)
+end
+# Get the internal radial displacement at p = (0, Rᵢ, 0)
+uᵣ_numeric_nonlinear_nᵢ = displacements(states_nonlinear_sol, nᵢ, 2);
+# Get the external radial displacement at p = (-Rₑ, 0, Lₖ)
+uᵣ_numeric_nonlinear_nₑ = displacements(states_nonlinear_sol, nₑ, 1);
 # -------------------------------
 # Analytic solution
 # -------------------------------
 t = last(λᵥ)
-A(t, Rᵢ, Rₑ, E, ν) = (1 + ν) * (1 - 2 * ν) * Rᵢ^2 * -pressure(t) / (E * (Rₑ^2 - Rᵢ^2))
-Avalue = A(t, Rᵢ, Rₑ, E, ν)
-B(t, Rᵢ, Rₑ, E, ν) = (1 + ν) * Rᵢ^2 * Rₑ^2 * -pressure(t) / (E * (Rₑ^2 - Rᵢ^2))
-Bvalue = B(t, Rᵢ, Rₑ, E, ν)
-@show uᵣᵢ_analytic = Avalue * Rᵢ + Bvalue / Rᵢ
-@show uᵣₑ_analytic = Avalue * Rₑ + Bvalue / Rₑ
-nothing
+"Analytic radial displacements uᵣ at radius`r` and time `t`."
+function uᵣ(
+    r::Real, t::Real,
+    E::Real=E, ν::Real=ν, p::Function=pressure,
+    Rᵢ::Real=Rᵢ, Rₑ::Real=Rₑ,
+)
+    "Constant A for the analytic solution."
+    A(t::Real, Rᵢ::Real, Rₑ::Real, E::Real, ν::Real, p::Function) =
+        (1 + ν) * (1 - 2 * ν) * Rᵢ^2 * -p(t) / (E * (Rₑ^2 - Rᵢ^2))
+    "Constant B for the analytic solution."
+    B(t::Real, Rᵢ::Real, Rₑ::Real, E::Real, ν::Real, p::Function) =
+        (1 + ν) * Rᵢ^2 * Rₑ^2 * -p(t) / (E * (Rₑ^2 - Rᵢ^2))
+    uᵣ = A(t, Rᵢ, Rₑ, E, ν, p) * r + B(t, Rᵢ, Rₑ, E, ν, p) / r
+end;
+uᵣ_analytic_nᵢ = [uᵣ(Rᵢ, t) for t in λᵥ];
+uᵣ_analytic_nₑ = [uᵣ(Rₑ, t) for t in λᵥ];
+uᵣ_analytic_p_rand = [uᵣ(rand_R, t) for t in λᵥ];
+#-----------------------------
+# Print & plots 
+#-----------------------------
+print_timer(title="Analysis with $(out_gmsh[:nelems]) elements and $(out_gmsh[:nnodes]) nodes")
+if plot_results
+    using Plots
+    vec_p = [-pressure(λ) for λ in λᵥ]
+    vec_p_non_in = [-pressure(λ) for λ in load_factors(nonlinear_analysis)]
+    fig = plot(
+        vec_p, uᵣ_numeric_nᵢ, label="numeric linear uᵣ n=(0, Rᵢ, 0)",
+        legend=:topleft, color=:orange, lw=2, ls=:dash, markershape=:circle,
+    )
+    plot!(fig,
+        vec_p, -uᵣ_numeric_nₑ, label="numeric linear uᵣ n=(-Rₑ, 0 , Lₖ)",
+        legend=:topleft, color=:skyblue, lw=2, ls=:solid, markershape=:square,
+    )
+    plot!(fig,
+        vec_p, uᵣ_analytic_nᵢ, label="analytic linear uᵣ(Rᵢ)",
+        legend=:topleft, color=:black, lw=2, ls=:dash, markershape=:none,
+    )
+    plot!(fig,
+        vec_p, uᵣ_analytic_nₑ, label="analytic linear uᵣ(Rₑ)",
+        legend=:topleft, color=:black, lw=2, ls=:solid
+    )
+    # Plot comparing linear and non linear solutions 
+    plot!(fig,
+        vec_p_non_in, uᵣ_numeric_nonlinear_nᵢ, label="non-linear uᵣ(0, Rᵢ, 0)",
+        color=:red, lw=2, marker=:circle, markersize=3
+    )
+    plot!(fig,
+        vec_p_non_in, -uᵣ_numeric_nonlinear_nₑ, label="non-linear uᵣ(-Rₑ, 0 , Lₖ)",
+        color=:blue, lw=2, marker=:circle, markersize=3
+    )
+    # add labels
+    xlabel!("λᵥ [MPa]")
+    ylabel!("uᵣ [mm]")
+    display(fig)
+end
+#-----------------------------
+# Test booleans
+#-----------------------------
+# Test symmetry and boundary conditions for a random slice
+#-------------------------------------------
+function test_solution_at_slice(
+    sol::AbstractSolution=states_lin_sol;
+    atol::Real=ATOL, atolr=ATOLR,
+    Rᵢ::Real=Rᵢ, Rₑ::Real=Rₑ, Lₖ::Real=Lₖ
+)
+    structure = ONSAS.structure(analysis(sol))
+    # Generic surface s at z = Lₖ 
+    rand_R, rand_θ₁, Lₖ = rand_point_cylinder(Rᵢ, Rₑ, Lₖ)
+    # Set by force Lₖ
+    rand_θ₂ = rand() * 2 * π
+    # Random point ∈ axis x
+    p_randᵢ = [rand_R, 0.0, Lₖ]
+    # Random point ∈ axis y
+    p_randⱼ = [0.0, rand_R, Lₖ]
+    # Random point between the internal and external surface
+    p_rand₁ = [rand_R * cos(rand_θ₁), rand_R * sin(rand_θ₁), Lₖ]
+    p_rand₂ = [rand_R * cos(rand_θ₂), rand_R * sin(rand_θ₂), Lₖ]
+    # Vector of points to test
+    vec_points = [p_randᵢ, p_randⱼ, p_rand₁, p_rand₂]
+    #
+    point_evaluator = PointEvalHandler(mesh(structure), vec_points)
+    U = displacements(sol, point_evaluator)
+    # Check uₖ = 0 ∀ p ∈ s
+    zero_uₖ = all([≈(norm(u[3]), 0.0, atol=atol) for u in U])
+    # Check uᵢ = 0 ∀ p ∈ s & ∈ axis y
+    Uᵢ_in_axis_y = displacements(states_lin_sol, point_evaluator, 2)[1]
+    zero_uₖ_axis_y = all([≈(norm(uᵢ_p_in_axis_y), 0.0, atol=atol) for uᵢ_p_in_axis_y in Uᵢ_in_axis_y])
+    # Check uⱼ = 0 ∀ p ∈ s & ∈ axis x
+    Uⱼ_in_axis_x = displacements(states_lin_sol, point_evaluator, 1)[2]
+    zero_uⱼ_axis_x = all([≈(norm(uⱼ_p_in_axis_y), 0.0, atol=atol) for uⱼ_p_in_axis_y in Uⱼ_in_axis_x])
+    # Check uᵣ(r,θ₁) =  uᵣ(r,θ₁)  at last time
+    rand₁_index = 3
+    uᵣ_rand₁ = sum(last.(U[rand₁_index][1:2]) .^ 2)
+    rand₂_index = 4
+    uᵣ_rand₂ = sum(last.(U[rand₂_index][1:2]) .^ 2)
+    uᵣ_not_depends_on_θ = ≈(uᵣ_rand₁, uᵣ_rand₂, atol=atolr)
+    return uᵣ_not_depends_on_θ, zero_uₖ, zero_uₖ_axis_y, zero_uⱼ_axis_x
+end;
+# Test simmetry and boundary conditions
+uᵣ_not_depends_on_θ, zero_uₖ, zero_uₖ_axis_y, zero_uⱼ_axis_x =
+    test_solution_at_slice(states_lin_sol, atol=ATOL, atolr=10 * ATOL)
+@testset "Case 1: Linear Analysis " begin
+    @test uᵣ_not_depends_on_θ
+    @test zero_uₖ
+    @test zero_uₖ_axis_y
+    @test zero_uⱼ_axis_x
+    @test uᵣ_numeric_p_rand ≈ uᵣ_analytic_p_rand atol = ATOL
+    @test uᵣ_analytic_nᵢ ≈ uᵣ_numeric_nᵢ atol = ATOL
+    @test uᵣ_analytic_nₑ ≈ -uᵣ_numeric_nₑ atol = ATOL
+end
+# Test simmetry and boundary conditions
+uᵣ_not_depends_on_θ_case2, zero_uₖ_case2, zero_uₖ_axis_y_case2, zero_uⱼ_axis_x_case2 =
+    test_solution_at_slice(states_lin_sol, atol=ATOL, atolr=10 * ATOL)
+@testset "Case 2: Non-Linear Analysis " begin
+    @test uᵣ_not_depends_on_θ_case2
+    @test zero_uₖ_case2
+    @test zero_uₖ_axis_y_case2
+    @test zero_uⱼ_axis_x_case2
+end

--- a/examples/uniaxial_extension/uniaxial_extension.jl
+++ b/examples/uniaxial_extension/uniaxial_extension.jl
@@ -246,7 +246,7 @@ function run_uniaxial_extension()
     rand_point_uⱼ = displacements(states_sol_case₂, eval_handler_rand, 2)
     rand_point_uₖ = displacements(states_sol_case₂, eval_handler_rand, 3)
     #-----------------------------
-    # Test boolean for CI  
+    # Test booleans
     #-----------------------------
     @testset "Case 1 Uniaxial Extension Example" begin
         @test analytics_λᵥ_case₁ ≈ numeric_λᵥ_case₁ rtol = RTOL


### PR DESCRIPTION
This example includes the following tests:

```julia
# Test simmetry and boundary conditions
uᵣ_not_depends_on_θ, zero_uₖ, zero_uₖ_axis_y, zero_uⱼ_axis_x =
    test_solution_at_slice(states_lin_sol, atol=ATOL, atolr=10 * ATOL)
@testset "Case 1: Linear Analysis " begin
    @test uᵣ_not_depends_on_θ
    @test zero_uₖ
    @test zero_uₖ_axis_y
    @test zero_uⱼ_axis_x
    @test uᵣ_numeric_p_rand ≈ uᵣ_analytic_p_rand atol = ATOL
    @test uᵣ_analytic_nᵢ ≈ uᵣ_numeric_nᵢ atol = ATOL
    @test uᵣ_analytic_nₑ ≈ -uᵣ_numeric_nₑ atol = ATOL
end
# Test simmetry and boundary conditions
uᵣ_not_depends_on_θ_case2, zero_uₖ_case2, zero_uₖ_axis_y_case2, zero_uⱼ_axis_x_case2 =
    test_solution_at_slice(states_lin_sol, atol=ATOL, atolr=10 * ATOL)
@testset "Case 2: Non-Linear Analysis " begin
    @test uᵣ_not_depends_on_θ_case2
    @test zero_uₖ_case2
    @test zero_uₖ_axis_y_case2
    @test zero_uⱼ_axis_x_case2
end
```
and these are the results obtained:
```julia
 The mesh contains 14617 elements and 2708 nodes. 
 ──────────────────────────────────────────────────────────────────────────────────────────────────────
     Analysis with 14617 elements and 2708 nodes              Time                    Allocations      
                                                     ───────────────────────   ────────────────────────
                  Tot / % measured:                       28.2s /  98.8%           37.2GiB /  99.9%    

 Section                                     ncalls     time    %tot     avg     alloc    %tot      avg
 ──────────────────────────────────────────────────────────────────────────────────────────────────────
 Solving the non-linear analysis 🐢->🐕           1    18.4s   66.3%   18.4s   25.0GiB   67.3%  25.0GiB
 Solving the linear analysis 🐢->🐕               1    9.13s   32.8%   9.13s   12.0GiB   32.2%  12.0GiB
 Building the linear structure ⚪                 1    129ms    0.5%   129ms   68.0MiB    0.2%  68.0MiB
 Building the non-linear structure 🔘             1   94.2ms    0.3%  94.2ms   65.9MiB    0.2%  65.9MiB
 Defining the linear analysis 👷 🔎 ⚪            1   21.8ms    0.1%  21.8ms   23.6MiB    0.1%  23.6MiB
 Defining the non-linear analysis 👲 🔎 🔘        1   17.6ms    0.1%  17.6ms   23.6MiB    0.1%  23.6MiB
 ──────────────────────────────────────────────────────────────────────────────────────────────────────
┌ Info: uᵣ(r,θ₁,L₁) = uᵣ(r,θ₂,L₂)?
└   uᵣ_not_depends_on_θ = true
Test Summary:            | Pass  Total  Time
Case 1: Linear Analysis  |    6      6  0.0s
┌ Info: uᵣ(r,θ₁,L₁) = uᵣ(r,θ₂,L₂)?
└   uᵣ_not_depends_on_θ_case2 = true
Test Summary:                | Pass  Total  Time
Case 2: Non-Linear Analysis  |    3      3  0.1s
Test.DefaultTestSet("Case 2: Non-Linear Analysis ", Any[], 3, false, false, true, 1.682085160780027e9, 1.682085160871188e9)
```

![image](https://user-images.githubusercontent.com/50339940/233652389-389e3cfe-024f-4bd1-b629-84d996ba4061.png)




