### PR TITLE
Gmsh IO pirnt and distinction between elements and faces

### DIFF
--- a/examples/cylinder_internal_pressure/cylinder_internal_pressure.jl
+++ b/examples/cylinder_internal_pressure/cylinder_internal_pressure.jl
@@ -22,9 +22,9 @@ NSTEPS = 9
 ## tolerances for testing
 ATOL = 1e-2 * (Rₑ - Rᵢ)
 ## Plot results
-plot_results = true
+plot_results = false
 ## Refinement mesh factor
-ms = 0.8
+ms = 0.75
 include("cylinder_mesh.jl")
 # -------------------------------
 # Structure
@@ -71,7 +71,11 @@ function cylinder_structure(
     # -------------------------------
     labels = [mat_label, entities_labels, bc_labels]
     filename = "cylinder"
-    msh_path = create_cylinder_mesh(Rᵢ, Rₑ, Lₖ, labels, filename, ms)
+    local msh_path
+    out = @capture_out begin
+        msh_path = create_cylinder_mesh(Rᵢ, Rₑ, Lₖ, labels, filename, ms)
+    end
+    gmsh_println(out)
     msh_mesh = MshFile(msh_path)
     # -------------------------------
     # Structure
@@ -177,7 +181,10 @@ uᵣ_analytic_p_rand = [uᵣ(rand_R, t) for t in λᵥ];
 #-----------------------------
 # Print & plots 
 #-----------------------------
-print_timer(title="Analysis with $(out_gmsh[:nelems]) elements and $(out_gmsh[:nnodes]) nodes")
+nnodes = length(nodes(mesh(linear_cylinder)));
+nelems = length(elements(mesh(linear_cylinder)));
+nfaces = length(faces(mesh(linear_cylinder)));
+print_timer(title="Analysis with $(nelems) elements and $nnodes nodes");
 if plot_results
     using Plots
     vec_p = [-pressure(λ) for λ in λᵥ]

--- a/examples/cylinder_internal_pressure/cylinder_internal_pressure_sketch.svg
+++ b/examples/cylinder_internal_pressure/cylinder_internal_pressure_sketch.svg
@@ -23,15 +23,15 @@
      inkscape:pagecheckerboard="0"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="0.71535497"
-     inkscape:cx="1195.2108"
-     inkscape:cy="1009.9881"
-     inkscape:window-width="1920"
-     inkscape:window-height="1041"
-     inkscape:window-x="0"
+     inkscape:zoom="1.0116647"
+     inkscape:cx="1342.342"
+     inkscape:cy="427.51319"
+     inkscape:window-width="960"
+     inkscape:window-height="1003"
+     inkscape:window-x="960"
      inkscape:window-y="39"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer2"
      inkscape:showpageshadow="0"
      inkscape:deskcolor="#505050"
      showguides="true" />
@@ -695,7 +695,7 @@
          id="tspan1645-09-3"
          style="stroke-width:0.199522"
          x="166.7856"
-         y="97.052521">11</tspan></text>
+         y="97.052521">10</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:7.9809px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.199522"
@@ -1631,7 +1631,7 @@
          id="tspan1645-09-7-8"
          style="stroke-width:0.199522"
          x="226.11961"
-         y="108.70805">12</tspan></text>
+         y="108.70805">11</tspan></text>
     <circle
        style="fill:#000000;stroke:#850000;stroke-width:0.589971;stroke-miterlimit:0.6"
        id="path1362-3-6-7-4-1-1-4"
@@ -1648,7 +1648,7 @@
          id="tspan1645-09-7-5-6-1"
          style="stroke-width:0.199522"
          x="165.50078"
-         y="71.72583">14</tspan></text>
+         y="71.72583">13</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:7.9809px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.199522"
@@ -1659,7 +1659,7 @@
          id="tspan1645-09-7-5-6-3-6-4-3"
          style="stroke-width:0.199522"
          x="246.97569"
-         y="115.7531">16</tspan></text>
+         y="115.7531">15</tspan></text>
     <circle
        style="fill:#000000;stroke:#850000;stroke-width:0.589971;stroke-miterlimit:0.6"
        id="path1362-3-6-7-4-1-9-7-6-3-0"
@@ -1676,7 +1676,7 @@
          id="tspan3217-3-4"
          style="stroke-width:0.199522"
          x="147.39188"
-         y="64.286667">18</tspan></text>
+         y="64.286667">17</tspan></text>
     <circle
        style="fill:#000000;stroke:#850000;stroke-width:0.589971;stroke-miterlimit:0.6"
        id="circle3221-9-4"
@@ -1699,7 +1699,7 @@
          id="tspan1645-09-7-5-8"
          style="stroke-width:0.199522"
          x="198.34973"
-         y="142.11938">13</tspan></text>
+         y="142.11938">12</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:7.9809px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.199522"
@@ -1710,7 +1710,7 @@
          id="tspan1645-09-7-5-6-3-5"
          style="stroke-width:0.199522"
          x="202.0712"
-         y="39.596161">15</tspan></text>
+         y="39.596161">14</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:7.9809px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.199522"
@@ -1721,7 +1721,7 @@
          id="tspan1645-09-7-5-6-3-6-9"
          style="stroke-width:0.199522"
          x="202.65564"
-         y="17.299669">19</tspan></text>
+         y="17.299669">18</tspan></text>
     <circle
        style="fill:#000000;stroke:#850000;stroke-width:0.589971;stroke-miterlimit:0.6"
        id="path1362-3-6-7-4-1-9-7-6-6"
@@ -1744,7 +1744,7 @@
          id="tspan3217-5"
          style="stroke-width:0.199522"
          x="198.23544"
-         y="163.59569">17</tspan></text>
+         y="163.59569">16</tspan></text>
     <circle
        style="fill:#000000;stroke:#850000;stroke-width:0.589971;stroke-miterlimit:0.6"
        id="circle3221-6"

--- a/src/Meshes/Gmsh.jl
+++ b/src/Meshes/Gmsh.jl
@@ -111,9 +111,9 @@ bc_label(mfile::MshFile, entity_index::Integer) = bc_label(mfile)[physical_index
 function gmsh_println(output)
     # Extract the number of nodes and elements as integers.
     num_nodes = parse(Int, match(r"(\d+) nodes (\d+) elements", output).captures[1])
-    num_elements = parse(Int, match(r"(\d+) nodes (\d+) elements", output).captures[2])
-    println("The mesh contains $num_elements elements and $num_nodes nodes. ")
-    dictionary([:nnodes => num_nodes, :nelems => num_elements])
+    num_entities = parse(Int, match(r"(\d+) nodes (\d+) elements", output).captures[2])
+    println("The mesh contains $num_entities entities and $num_nodes nodes. ")
+    dictionary([:nnodes => num_nodes, :num_entities => num_entities])
 end
 
 end # module


### PR DESCRIPTION
Now a finner mesh is required to validate the analytical solution:

![image](https://user-images.githubusercontent.com/50339940/233788847-52dcd239-f114-485d-bf8f-a1eaa365426b.png)

Also the mesh is defined using Gmsh.jl