### PR TITLE
Replace material into `Structure` 

### DIFF
--- a/src/Meshes/Meshes.jl
+++ b/src/Meshes/Meshes.jl
@@ -87,6 +87,9 @@ num_nodes(m::AbstractMesh) = length(nodes(m))
 "Return a `Vector` of `Face`s defined in the `AbstractMesh` `m`."
 faces(m::AbstractMesh) = m.faces
 
+"Return the number of `Face`s of the `AbstractMesh` `m`."
+num_faces(m::AbstractMesh) = length(faces(m))
+
 "Return the `Element`s of the `AbstractMesh` `m`."
 elements(m::AbstractMesh) = m.elements
 

--- a/src/StructuralModel/StructuralModel.jl
+++ b/src/StructuralModel/StructuralModel.jl
@@ -10,10 +10,10 @@ using Reexport: @reexport
 @reexport using ..Elements
 @reexport using ..BoundaryConditions
 @reexport using ..Meshes
-using ..Utils: label
+using ..Utils
 
-import ..Elements: dofs, nodes
-import ..Meshes: mesh, num_dofs, elements, num_elements, num_nodes
+@reexport import ..Meshes: mesh, dofs, num_dofs, nodes, num_nodes, faces, num_faces,
+                           elements, num_elements
 
 export Structure, materials, boundary_conditions, num_free_dofs, free_dofs
 
@@ -26,8 +26,12 @@ include("./StructuralEntities.jl")
 # Structure
 # ==========
 
-""" Abstract supertype to define a new structure. An `AbstractStructure` object facilitates the process of assigning materials, 
-elements, and boundary conditions to the mesh. Moreover this struct is used to solve an specific structural analysis. 
+""" 
+Abstract supertype to define a new structure. 
+An `AbstractStructure` object facilitates the process of assigning materials, elements, 
+and boundary conditions to the mesh. Moreover this struct is used to solve an specific 
+structural analysis. 
+
 **Common methods:**
 
 ## Mesh: 
@@ -37,6 +41,8 @@ elements, and boundary conditions to the mesh. Moreover this struct is used to s
 * [`num_free_dofs`](@ref)
 * [`nodes`](@ref)
 * [`num_nodes`](@ref)
+* [`faces`](@ref)
+* [`num_faces`](@ref)
 * [`elements`](@ref)
 * [`num_elements`](@ref)
 * [`mesh`](@ref)
@@ -81,6 +87,12 @@ elements(s::AbstractStructure) = elements(mesh(s))
 
 "Return the number of `Element`s of the `AbstractStructure` `s`"
 num_elements(s::AbstractStructure) = num_elements(mesh(s))
+
+"Return the `Face`s of the `AbstractStructure` `s`"
+faces(s::AbstractStructure) = faces(mesh(s))
+
+"Return the number of `Face`s of the `AbstractStructure` `s`"
+num_faces(s::AbstractStructure) = num_faces(mesh(s))
 
 # Boundary Conditions 
 "Return the `StructuralBoundaryConditions` of the `AbstractStructure` `s`"

--- a/test/structural_model.jl
+++ b/test/structural_model.jl
@@ -36,6 +36,7 @@ truss₄ = Truss(n₄, n₃, s)
 # Mesh
 # Materials
 steel = SVK(E, ν, "steel")
+new_steel = SVK(2E, ν, "new_steel")
 aluminum = SVK(E / 3, ν, "aluminium")
 mat_dict = dictionary([steel => [truss₁, truss₃], aluminum => [truss₂]])
 s_materials = StructuralMaterials(mat_dict)
@@ -61,6 +62,15 @@ s_boundary_conditions = StructuralBoundaryConditions(node_bc, face_bc, elem_bc)
     @test s_materials[truss₁] == steel
     @test s_materials["steel"] == steel
     @test truss₁ ∈ s_materials[steel] && truss₃ ∈ s_materials[steel]
+    insert!(s_materials, new_steel)
+    @test new_steel ∈ keys(element_materials(s_materials))
+    delete!(s_materials, new_steel)
+    @test new_steel ∉ keys(element_materials(s_materials))
+    material_label_to_be_replaced = "steel"
+    replace!(s_materials, new_steel, material_label_to_be_replaced)
+    @test new_steel ∈ keys(element_materials(s_materials))
+    @test steel ∉ keys(element_materials(s_materials))
+    @test s_materials[truss₁] == new_steel
 end
 
 @testset "ONSAS.StructuralModel.StructuralBoundaryConditions" begin
@@ -160,12 +170,24 @@ end
     @test nodes(s) == nodes(mesh(s))
     @test num_nodes(s) == length(nodes(mesh(s)))
 
+    # Faces
+    @test faces(s) == faces(mesh(s))
+    @test num_faces(s) == length(faces(mesh(s)))
+
     # Elements
     @test elements(s) == elements(mesh(s))
     @test num_elements(s) == length(elements(mesh(s)))
 
     # Mesh
     @test mesh(s) == s_mesh
+
+    # Materials
+    @test materials(s) == s_materials
+    # Replace material 
+    label_material_to_be_replaced = "new_steel"
+    replace!(s, steel, label_material_to_be_replaced)
+    @test steel ∈ keys(element_materials(materials(s)))
+    @test new_steel ∉ keys(element_materials(materials(s)))
 
     # Boundary conditions
     @test boundary_conditions(s) == s_boundary_conditions


### PR DESCRIPTION
Closes #230 

Now the cylinder is solved with this feature and a single `cyilinder::Structure`

These are the results:
```julia
The mesh contains 8488 entities and 1666 nodes. 
┌ Info: uᵣ(r,θ₁,L₁) = uᵣ(r,θ₂,L₂)?
└   uᵣ_not_depends_on_θ = true
Test Summary:            | Pass  Total  Time
Case 1: Linear Analysis  |    6      6  0.0s
┌ Info: uᵣ(r,θ₁,L₁) = uᵣ(r,θ₂,L₂)?
└   uᵣ_not_depends_on_θ_case2 = true
Test Summary:                | Pass  Total  Time
Case 2: Non-Linear Analysis  |    3      3  0.0s
 ──────────────────────────────────────────────────────────────────────────────────────────────
  Analysis with 5246 elements and 1664 nodes          Time                    Allocations      
                                             ───────────────────────   ────────────────────────
              Tot / % measured:                   13.0s /  95.2%           18.6GiB /  99.5%    

 Section                             ncalls     time    %tot     avg     alloc    %tot      avg
 ──────────────────────────────────────────────────────────────────────────────────────────────
 Solving the non-linear analysis ...      1    7.83s   63.1%   7.83s   12.5GiB   67.2%  12.5GiB
 Solving the linear analysis 🐢->🐕       1    4.19s   33.8%   4.19s   5.96GiB   32.1%  5.96GiB
 Building the structure ⚪                1    359ms    2.9%   359ms   97.2MiB    0.5%  97.2MiB
 Defining the non-linear analysis...      1   13.3ms    0.1%  13.3ms   11.7MiB    0.1%  11.7MiB
 Defining the linear analysis 👷 🔎...    1   13.3ms    0.1%  13.3ms   11.7MiB    0.1%  11.7MiB
 Replacing the non-linear materia...      1   22.5μs    0.0%  22.5μs   0.98KiB    0.0%  0.98KiB
 ──────────────────────────────────────────────────────────────────────────────────────────────
```