### PR TITLE
Faster local dofs

### DIFF
--- a/src/Entities/Entities.jl
+++ b/src/Entities/Entities.jl
@@ -149,17 +149,19 @@ Return local dofs given a vector of local dof symbols.
 This method extracts all node dofs with the same symbol as local_dof_symbol.
 """
 function local_dofs(e::AbstractElement)
-    local_dof_symbols = local_dof_symbol(e)
-    local_dofs = Vector{Dof}()
-    element_dofs = dofs(e)
-    for dof_symbol in local_dof_symbols
-        if dof_symbol ∉ keys(element_dofs)
-            error("Element $(e.label) does not have dofs with symbol $(dof_symbol)")
-        else
-            push!(local_dofs, element_dofs[dof_symbol]...)
+    lds = local_dof_symbol(e)
+    res = Dof[]
+    for n in nodes(e)
+        # For each node, append to the result the dofs restricted to local dof symbols.
+        dict = dofs(n)
+        for s in lds
+            if !haskey(dict, s)
+                throw(ArgumentError("Element $(e.label) doesn't have dofs with symbol $s."))
+            end
+            append!(res, dict[s])
         end
     end
-    return local_dofs
+    res
 end
 
 "Return the internal forces vector of an `AbstractElement` `e` with an `AbstractMaterial` `m`."

--- a/src/Entities/Entities.jl
+++ b/src/Entities/Entities.jl
@@ -151,10 +151,11 @@ This method extracts all node dofs with the same symbol as local_dof_symbol.
 function local_dofs(e::AbstractElement)
     lds = local_dof_symbol(e)
     res = Dof[]
-    for n in nodes(e)
-        # For each node, append to the result the dofs restricted to local dof symbols.
-        dict = dofs(n)
-        for s in lds
+    for s in lds
+        # Store in the resulting array the dofs per element that match each local dof.
+        # Traversal order matters, since `local_dofs` is then used to build reduced matrices.
+        for n in nodes(e)
+            dict = dofs(n)
             if !haskey(dict, s)
                 throw(ArgumentError("Element $(e.label) doesn't have dofs with symbol $s."))
             end


### PR DESCRIPTION
This branch is based on https://github.com/ONSAS/ONSAS.jl/pull/388,  but is independent.

---

Before:

```julia
julia> @benchmark local_dofs($tetra)
BenchmarkTools.Trial: 10000 samples with 84 evaluations.
 Range (min … max):  813.988 ns … 31.485 μs  ┊ GC (min … max):  0.00% … 96.09%
 Time  (median):     831.345 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   938.150 ns ±  1.722 μs  ┊ GC (mean ± σ):  10.43% ±  5.51%

      ▂█▆▄▅                                                     
  ▁▂▄▆██████▆▆▄▄▄▃▃▃▂▃▂▂▂▂▂▂▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  814 ns          Histogram: frequency by time          943 ns <

 Memory estimate: 1.77 KiB, allocs estimate: 19.
```


After:

```julia
julia> @benchmark local_dofs($tetra)
BenchmarkTools.Trial: 10000 samples with 864 evaluations.
 Range (min … max):  137.731 ns …   3.026 μs  ┊ GC (min … max):  0.00% … 94.03%
 Time  (median):     140.191 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   168.730 ns ± 270.235 ns  ┊ GC (mean ± σ):  16.04% ±  9.42%

  █                                                              
  █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂ ▂
  138 ns           Histogram: frequency by time         2.79 μs <

 Memory estimate: 544 bytes, allocs estimate: 4.
```

