### PR TITLE
Sparse Arrays API

### DIFF
--- a/src/StructuralAnalyses/StaticAnalyses.jl
+++ b/src/StructuralAnalyses/StaticAnalyses.jl
@@ -7,6 +7,7 @@ module StaticAnalyses
 
 using Dictionaries: dictionary
 using Reexport
+using SparseArrays
 
 using ..Materials
 using ..Entities
@@ -120,7 +121,9 @@ end
 function reset_assemble!(state::StaticState)
     reset!(assembler(state))
     internal_forces(state) .= 0.0
-    tangent_matrix(state).nzval .= 0.0
+    K = tangent_matrix(state)
+    I, J, V = findnz(tangent_matrix(state))
+    K[I, J] .= zeros(eltype(V))
     nothing
 end
 


### PR DESCRIPTION
Closes #420. A comparisson against `vtk` branch (this branch is outdated with the master, hence the `findall` method still in use)

## Not using `findall`
| ID                                                                                                                     | time            | GC time   | memory          | allocations |
|------------------------------------------------------------------------------------------------------------------------|----------------:|----------:|----------------:|------------:|
| `["uniaxial_compression", "solve, ms = 0.1, nelems = 9292, nnodes = 2147"]`                                            | 260.118 ms (5%) | 45.260 ms | 557.27 MiB (1%) |     1663593 |
| `["uniaxial_extension", "solve, ms = 0.1, nelems = 9292, nnodes = 2147"]`                                              | 268.287 ms (5%) | 33.422 ms | 395.07 MiB (1%) |     1459169 |

## Using `findall`
| ID                                                                                                                     | time            | GC time   | memory          | allocations |
|------------------------------------------------------------------------------------------------------------------------|----------------:|----------:|----------------:|------------:|
| `["uniaxial_compression", "solve, ms = 0.1, nelems = 9292, nnodes = 2147"]`                                            | 281.690 ms (5%) | 30.078 ms | 559.82 MiB (1%) |     1663661 |
| `["uniaxial_extension", "solve, ms = 0.1, nelems = 9292, nnodes = 2147"]`                                              | 282.470 ms (5%) | 18.785 ms | 397.62 MiB (1%) |     1459237 |
