### PR TITLE
Inplace cosserat stress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ Manifest.toml
 
 # Benchmark files.
 tune.json
-results.md
+*results.md

--- a/src/Entities/Trusses.jl
+++ b/src/Entities/Trusses.jl
@@ -4,6 +4,7 @@ module Trusses
 using SparseArrays
 using Reexport
 using StaticArrays
+using LinearAlgebra
 
 using ..Materials
 using ..HyperElasticMaterials
@@ -138,8 +139,8 @@ function internal_forces(m::AbstractHyperElasticMaterial, e::Truss{dim,RotatedEn
     K_geo = 𝐒₁₁ * A / l_def * (B_dif' * B_dif - TTcl * (TTcl'))
     Kᵢₙₜ_e = Kₘ + K_geo
 
-    σ_e = spzeros(3, 3)
-    ϵ_e = spzeros(3, 3)
+    σ_e = Symmetric(Matrix{Float64}(undef, (3, 3)))
+    ϵ_e = Symmetric(Matrix{Float64}(undef, (3, 3)))
     # Piola stress
     σ_e[1, 1] = 𝐒₁₁ * l_def / l_ref
     ϵ_e[1, 1] = ϵ
@@ -168,8 +169,8 @@ function internal_forces(m::AbstractHyperElasticMaterial, e::Truss{dim,GreenStra
     Kᵢₙₜ_e = 𝐒₁₁ * A / l_ref * Ge + E * A * l_ref * (b_sum' * b_sum)
 
     # Frist Piola stress
-    σ_e = spzeros(3, 3)
-    ϵ_e = spzeros(3, 3)
+    σ_e = Symmetric(Matrix{Float64}(undef, (3, 3)))
+    ϵ_e = Symmetric(Matrix{Float64}(undef, (3, 3)))
     σ_e[1, 1] = 𝐒₁₁ * l_def / l_ref
     ϵ_e[1, 1] = ϵ
 

--- a/src/Materials/HyperElasticMaterials.jl
+++ b/src/Materials/HyperElasticMaterials.jl
@@ -3,7 +3,7 @@ module HyperElasticMaterials
 
 using ..Materials: AbstractMaterial
 
-export AbstractHyperElasticMaterial, cosserat_stress, strain_energy
+export AbstractHyperElasticMaterial, cosserat_stress!, strain_energy
 
 """ Abstract supertype for all hyper-elastic material models.
 
@@ -12,7 +12,7 @@ These materials are characterized by a strain energy function ψ  that depends o
 
 **Abstract Methods**
 * [`strain_energy`](@ref)
-* [`cosserat_stress`](@ref)
+* [`cosserat_stress!`](@ref)
 
 **Abstract fields**
 * label
@@ -26,6 +26,6 @@ function strain_energy(m::AbstractHyperElasticMaterial, 𝔼) end
 
 "Return the Cosserat or Second-Piola Kirchhoff stress tensor `𝕊` given an `AbstractMaterial` `m` and the
 Green-Lagrange strain tensor `𝔼`."
-function cosserat_stress(m::AbstractMaterial, 𝔼::AbstractMatrix) end
+function cosserat_stress!(m::AbstractMaterial, 𝔼::AbstractMatrix) end
 
 end

--- a/src/Materials/LinearElasticMaterials.jl
+++ b/src/Materials/LinearElasticMaterials.jl
@@ -16,6 +16,8 @@ An `AbstractLinearElasticMaterial` object facilitates the process of using elast
 * [`shear_modulus`](@ref)
 * [`poisson_ratio`](@ref)
 * [`elasticity_modulus`](@ref)
+* [`bulk_modulus`](@ref)
+* [`stress!`](@ref)
 
 **Abstract fields**
 * label

--- a/src/Materials/SVKMaterial.jl
+++ b/src/Materials/SVKMaterial.jl
@@ -8,7 +8,7 @@ using ..Utils
 
 @reexport import ..LinearElasticMaterials: lame_parameters, elasticity_modulus, shear_modulus,
                                            bulk_modulus, poisson_ratio
-@reexport import ..HyperElasticMaterials: cosserat_stress, strain_energy
+@reexport import ..HyperElasticMaterials: cosserat_stress!, strain_energy
 
 export SVK
 
@@ -84,16 +84,18 @@ end
 
 "Return the Cosserat or Second-Piola Kirchoff stress tensor `𝕊`
 considering a `SVK` material `m` and the Lagrangian Green
-strain tensor `𝔼`.Also this function provides `∂𝕊∂𝔼` for the iterative method."
-function cosserat_stress(m::SVK, 𝔼::AbstractMatrix)
+strain tensor `𝔼`.Also this function provides `∂S∂E` for the iterative method."
+function cosserat_stress!(S::AbstractMatrix{<:Real}, ∂S∂E::Matrix{<:Real},
+                          m::SVK, E::AbstractMatrix;
+                          eye_cache::AbstractMatrix{<:Real}=eye(3),
+                          ones_cache::AbstractMatrix{<:Real}=ones(3, 3))
     λ, G = lame_parameters(m)
-    𝕊 = λ * tr(𝔼) * eye(3) + 2 * G * 𝔼
+    S .= λ * tr(E) * eye_cache + 2 * G * E
 
-    ∂𝕊∂𝔼 = zeros(6, 6)
-    ∂𝕊∂𝔼[1:3, 1:3] = λ * ones(3, 3) + 2 * G * eye(3)
-    ∂𝕊∂𝔼[4:6, 4:6] = G * eye(3)
+    ∂S∂E[1:3, 1:3] .= λ * ones_cache + 2 * G * eye_cache
+    ∂S∂E[4:6, 4:6] .= G * eye_cache
 
-    𝕊, ∂𝕊∂𝔼
+    S, ∂S∂E
 end
 
 end

--- a/src/StructuralAnalyses/StructuralAnalyses.jl
+++ b/src/StructuralAnalyses/StructuralAnalyses.jl
@@ -92,8 +92,9 @@ function assemble!(st::AbstractStructuralState, kₛ_e::AbstractMatrix, e::Abstr
 end
 
 "Assembles the element `e` stress σₑ and strain ϵₑ into the structural state."
-function assemble!(st::AbstractStructuralState, σₑ::E, ϵₑ::E,
-                   e::AbstractElement) where {E<:Union{Real,AbstractMatrix}}
+function assemble!(st::AbstractStructuralState, σₑ::ST, ϵₑ::ET,
+                   e::AbstractElement) where {ST<:Union{Real,AbstractMatrix},
+                                              ET<:Union{Real,AbstractMatrix}}
     stress(st)[e] .= σₑ
     strain(st)[e] .= ϵₑ
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,9 +1,9 @@
 module Utils
 
-using LinearAlgebra: Diagonal
+using LinearAlgebra
 
 export ScalarWrapper, label, unwrap, eye, row_vector, @debugtime, voigt, Label, NO_LABEL,
-       Density, Field, index
+       Density, Field, index, fill_symmetric_matrix!, INDEXES_TO_VOIGT
 
 #================================#
 # Generic functions to overload  #
@@ -42,6 +42,21 @@ eye(m::Integer, T=Bool) = Diagonal(ones(T, m))
 "Transforms a vector of vectors into a 1D row vector."
 row_vector(v::Vector{<:AbstractVector{T}}) where {T} = reduce(vcat, v)
 
+function fill_symmetric_matrix!(S::Symmetric{T},
+                                S₁₁::T, S₂₂::T, S₃₃::T, S₂₃::T, S₁₃::T, S₁₂::T) where {T}
+    A = parent(S)
+    S[1, 1] = S₁₁
+    S[2, 2] = S₂₂
+    S[3, 3] = S₃₃
+    A[2, 3] = S₂₃
+    A[1, 3] = S₁₃
+    A[1, 2] = S₁₂
+end
+
+"Indexes to transform form Tensors.jl to Voigt nomenclature."
+const INDEXES_TO_VOIGT = [(1, 1), (2, 2), (3, 3), (2, 3), (1, 3), (1, 2)]
+
+#TODO: Replace indexes
 "Return the tensor `𝕋` in Voigt notation."
 function voigt(𝕋::AbstractMatrix, α::Real=1)
     return [𝕋[1, 1], 𝕋[2, 2], 𝕋[3, 3], α * 𝕋[2, 3], α * 𝕋[1, 3], α * 𝕋[1, 2]]

--- a/test/entities/trusses.jl
+++ b/test/entities/trusses.jl
@@ -105,6 +105,6 @@ end
     stress(t, u_global_structure[local_dofs(t)]) == σ_e
     @test norm(fᵢₙₜ_e) == 0
     @test Kᵢₙₜ_e[1] == E * A / l_def
-    @test norm(σ_e) == 0
-    @test norm(ϵ_e) == 0
+    @test norm(σ_e[1, 1]) == 0
+    @test norm(ϵ_e[1, 1]) == 0
 end

--- a/test/materials/materials.jl
+++ b/test/materials/materials.jl
@@ -124,13 +124,15 @@ Khyper = λhyper + 2 * Ghyper / 3
     @test label(svk_hyper) == Symbol(l)
 
     # Constitutive driver svk type SVK
-    𝕊_svk, ∂𝕊∂𝔼_svk = cosserat_stress(svk, 𝔼)
-
+    𝕊_svk = Symmetric(zeros(3, 3))
+    ∂𝕊∂𝔼_svk = zeros(6, 6)
+    cosserat_stress!(𝕊_svk, ∂𝕊∂𝔼_svk, svk, 𝔼)
     @test 𝕊_svk ≈ 𝕊_test rtol = RTOL
     @test ∂𝕊∂𝔼_svk ≈ ∂𝕊∂𝔼_test rtol = RTOL
-
-    𝕊_hyper, ∂𝕊∂𝔼_hyper = cosserat_stress(svk_hyper, 𝔼)
-
+    # Constitutive driver HyperElasticMateiral
+    𝕊_hyper = Symmetric(zeros(3, 3))
+    ∂𝕊∂𝔼_hyper = zeros(6, 6)
+    cosserat_stress!(𝕊_hyper, ∂𝕊∂𝔼_hyper, svk_hyper, 𝔼)
     @test 𝕊_hyper ≈ 𝕊_test rtol = RTOL
     @test ∂𝕊∂𝔼_svk ≈ ∂𝕊∂𝔼_test rtol = RTOL
 end
@@ -170,8 +172,13 @@ end
     neo_hyper = HyperElastic([bulk_modulus(neo_flexible), shear_modulus(neo_flexible)],
                              strain_energy_neo, l)
 
-    𝕊_hyper, ∂𝕊∂𝔼_hyper = cosserat_stress(neo_hyper, 𝔼)
-    𝕊_neo, ∂𝕊∂𝔼_neo = cosserat_stress(neo_flexible, 𝔼)
+    𝕊_hyper = Symmetric(zeros(3, 3))
+    ∂𝕊∂𝔼_hyper = zeros(6, 6)
+    𝕊_neo = Symmetric(zeros(3, 3))
+    ∂𝕊∂𝔼_neo = zeros(6, 6)
+
+    cosserat_stress!(𝕊_hyper, ∂𝕊∂𝔼_hyper, neo_hyper, 𝔼)
+    cosserat_stress!(𝕊_neo, ∂𝕊∂𝔼_neo, neo_flexible, 𝔼)
 
     @test 𝕊_hyper ≈ 𝕊_neo rtol = RTOL
     @test ∂𝕊∂𝔼_hyper ≈ ∂𝕊∂𝔼_neo rtol = RTOL

--- a/test/structural_analyses/static_analyses.jl
+++ b/test/structural_analyses/static_analyses.jl
@@ -153,7 +153,7 @@ sst_rand = StaticState(free_dofs(s), ΔUᵏ, Uᵏ, Fₑₓₜᵏ, Fᵢₙₜᵏ,
     fᵢₙₜ_e_1 = rand(6)
     k_e_1 = rand(6, 6)
     σ_e_1 = rand(3, 3)
-    ϵ_e_1 = rand(3, 3)
+    ϵ_e_1 = Symmetric(rand(3, 3))
     assemble!(default_s, fᵢₙₜ_e_1, truss₁)
     @test internal_forces(default_s)[1:6] ≈ fᵢₙₜ_e_1 rtol = RTOL
     assemble!(default_s, k_e_1, truss₁)
@@ -163,7 +163,7 @@ sst_rand = StaticState(free_dofs(s), ΔUᵏ, Uᵏ, Fₑₓₜᵏ, Fᵢₙₜᵏ,
     fᵢₙₜ_e_2 = rand(6)
     k_e_2 = rand(6, 6)
     σ_e_2 = rand(3, 3)
-    ϵ_e_2 = rand(3, 3)
+    ϵ_e_2 = Symmetric(rand(3, 3))
     assemble!(default_s, fᵢₙₜ_e_2, truss₂)
     assemble!(default_s, k_e_2, truss₂)
     assemble!(default_s, σ_e_2, ϵ_e_2, truss₂)


### PR DESCRIPTION
Closes #437 

### Main
```julia
"uniaxial_extension" => 5-element BenchmarkTools.BenchmarkGroup:
    "solve, ms = 0.3, nelems = 580, nnodes = 201" => Trial(16.441 ms)
    "solve, ms = 0.1, nelems = 9292, nnodes = 2147" => Trial(300.951 ms)
    "solve, ms = 0.2, nelems = 1343, nnodes = 400" => Trial(39.159 ms)
    "solve, ms = 0.5, nelems = 144, nnodes = 62" => Trial(3.747 ms)
    "solve, ms = 0.4, nelems = 256, nnodes = 107" => Trial(7.018 ms)
"uniaxial_compression" => 5-element BenchmarkTools.BenchmarkGroup:
    "solve, ms = 0.3, nelems = 580, nnodes = 201" => Trial(14.801 ms)
    "solve, ms = 0.1, nelems = 9292, nnodes = 2147" => Trial(281.064 ms)
    "solve, ms = 0.2, nelems = 1343, nnodes = 400" => Trial(35.352 ms)
    "solve, ms = 0.5, nelems = 144, nnodes = 62" => Trial(3.412 ms)
    "solve, ms = 0.4, nelems = 256, nnodes = 107" => Trial(6.384 ms)
```

### This branch
```julia
"uniaxial_extension" => 5-element BenchmarkTools.BenchmarkGroup:
    tags: []
    "solve, ms = 0.3, nelems = 580, nnodes = 201" => Trial(16.355 ms)
    "solve, ms = 0.1, nelems = 9292, nnodes = 2147" => Trial(294.047 ms)
    "solve, ms = 0.2, nelems = 1343, nnodes = 400" => Trial(38.229 ms)
    "solve, ms = 0.5, nelems = 144, nnodes = 62" => Trial(3.793 ms)
    "solve, ms = 0.4, nelems = 256, nnodes = 107" => Trial(7.040 ms)
"uniaxial_compression" => 5-element BenchmarkTools.BenchmarkGroup:
    tags: []
    "solve, ms = 0.3, nelems = 580, nnodes = 201" => Trial(14.415 ms)
    "solve, ms = 0.1, nelems = 9292, nnodes = 2147" => Trial(275.075 ms)
    "solve, ms = 0.2, nelems = 1343, nnodes = 400" => Trial(34.459 ms)
    "solve, ms = 0.5, nelems = 144, nnodes = 62" => Trial(3.317 ms)
    "solve, ms = 0.4, nelems = 256, nnodes = 107" => Trial(6.192 ms)
```