### PR TITLE
`_unwrap` method deleted

### DIFF
--- a/src/StructuralAnalyses/LinearStaticAnalyses.jl
+++ b/src/StructuralAnalyses/LinearStaticAnalyses.jl
@@ -67,7 +67,7 @@ end
 
 function Base.show(io::IO, sa::LinearStaticAnalysis)
     println("LinearStaticAnalysis for:")
-    println("• Current load factor $(unwrap(sa.current_step))/$(length(load_factors(sa))).")
+    println("• Current load factor $(sa.current_step))/$(length(load_factors(sa))).")
     show(io, sa.s)
     show(io, sa.state)
 end

--- a/src/StructuralAnalyses/NonLinearStaticAnalyses.jl
+++ b/src/StructuralAnalyses/NonLinearStaticAnalyses.jl
@@ -59,7 +59,7 @@ end
 
 function Base.show(io::IO, sa::NonLinearStaticAnalysis)
     println("NonLinearStaticAnalysis for:")
-    println("• Current load factor of $(unwrap(sa.current_step)).")
+    println("• Current load factor of $(sa.current_step).")
     show(io, sa.s)
     show(io, sa.state)
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -2,7 +2,7 @@ module Utils
 
 using LinearAlgebra
 
-export label, unwrap, eye, row_vector, @debugtime, voigt, Label, NO_LABEL, Density, Field, index,
+export label, eye, row_vector, @debugtime, voigt, Label, NO_LABEL, Density, Field, index,
        fill_symmetric_matrix!, INDEXES_TO_VOIGT
 
 #================================#
@@ -16,9 +16,6 @@ function dofs end
 
 "Return the label of an object."
 function label end
-
-"Unwraps the object fields."
-function _unwrap end
 
 "Apply one object to the other."
 function apply! end


### PR DESCRIPTION
Since `ScalarWrapper` object is deprecated the _unwrap method is no longer useful. 

Closes #451 